### PR TITLE
Improve compatibility with custom deaths, fix PAPI error

### DIFF
--- a/src/main/java/org/alexdev/unlimitednametags/listeners/PlayerListener.java
+++ b/src/main/java/org/alexdev/unlimitednametags/listeners/PlayerListener.java
@@ -135,7 +135,7 @@ public class PlayerListener implements PackSendHandler {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerDeath(@NotNull PlayerDeathEvent event) {
         diedPlayers.add(event.getEntity().getUniqueId());
         plugin.getNametagManager().removeAllViewers(event.getEntity());

--- a/src/main/java/org/alexdev/unlimitednametags/placeholders/PlaceholderManager.java
+++ b/src/main/java/org/alexdev/unlimitednametags/placeholders/PlaceholderManager.java
@@ -52,7 +52,7 @@ public class PlaceholderManager {
     private int index = maxIndex;
     private int mmIndex = maxMIndex;
     private DecimalFormat decimalFormat;
-    private final UntPapiExpansion untPapiExpansion;
+    private UntPapiExpansion untPapiExpansion;
 
     private BigDecimal miniGradientIndexBD = new BigDecimal("-1.0");
     private final BigDecimal stepBD = new BigDecimal("0.1");
@@ -73,8 +73,10 @@ public class PlaceholderManager {
                 .expiration(2, TimeUnit.MINUTES)
                 .build();
         this.formattedPhaseValues = Maps.newConcurrentMap();
-        this.untPapiExpansion = new UntPapiExpansion(plugin);
-        this.untPapiExpansion.register();
+        if (this.papiManager.isPapiEnabled()) {
+            this.untPapiExpansion = new UntPapiExpansion(plugin);
+            this.untPapiExpansion.register();
+        }
         this.placeholdersReplacements = Maps.newConcurrentMap();
         reloadPlaceholdersReplacements();
         createDecimalFormat();
@@ -159,7 +161,9 @@ public class PlaceholderManager {
 
     public void close() {
         this.executorService.shutdown();
-        this.untPapiExpansion.unregister();
+        if (this.papiManager.isPapiEnabled()) {
+            this.untPapiExpansion.unregister();
+        }
     }
 
 


### PR DESCRIPTION
Some plugins, especially minigame ones like my own, cancel `PlayerDeathEvent` using Paper functionality and use their own custom death handling. Since this plugin doesn't listen for it, and the respawn event usually not called after, this will result in nametags disappearing. Ignoring the cancelled event at a higher priority fixes this. Tested working on a Paper server, but not sure if it will work on Spigot due to #29.

While testing on a fresh server I also discovered the plugin doesn't load if PAPI is not installed, so I patched that too.