### PR TITLE
Update CreativeHook.java

### DIFF
--- a/src/main/java/org/alexdev/unlimitednametags/hook/creative/CreativeHook.java
+++ b/src/main/java/org/alexdev/unlimitednametags/hook/creative/CreativeHook.java
@@ -51,6 +51,9 @@ public interface CreativeHook {
     @SuppressWarnings("UnstableApiUsage")
     default Optional<Model> findModel(@NotNull ItemStack item) {
         final ResourcePack pack = getResourcePack();
+
+        if (pack == null) return Optional.empty();
+
         final Map<Integer, Model> cmdCache = getCmdCache().computeIfAbsent(item.getType().getKey(), k -> Maps.newConcurrentMap());
 
         final ItemMeta itemMeta = item.getItemMeta();


### PR DESCRIPTION
Null check for -> java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "team.unnamed.creative.ResourcePack.model(net.kyori.adventure.key.Key)" because "pack" is null