### PR TITLE
Avoid nametag errors when players are in different worlds

### DIFF
--- a/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
+++ b/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
@@ -277,6 +277,10 @@ public class PacketNameTag {
             return false;
         }
 
+        if (player.getWorld() != owner.getWorld()) {
+            return false;
+        }
+
         if (isPlayerChannelNotValid(player) || isPlayerChannelNotValid(owner)) {
             return false;
         }


### PR DESCRIPTION
Prevents potential nametag issues when players are in different worlds.
Closes #34 