### PR TITLE
Allow Null/Missing Permissions For NameTags

### DIFF
--- a/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
+++ b/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
 
     public NameTag getNametag(Player player) {
         return nameTags.entrySet().stream()
-                .filter(entry -> player.hasPermission(entry.getValue().permission))
+                .filter(entry -> entry.getValue().permission == null || player.hasPermission(entry.getValue().permission))
                 .findFirst()
                 .map(Map.Entry::getValue)
                 .orElse(nameTags.get("default"));


### PR DESCRIPTION
### Summary
Allow NameTags to work when permissions are `null` or missing.

### Changes
- Skip/ignore missing permission checks instead of throwing errors.

### Result
More flexible and stable behavior with incomplete permissions in configs.