### PR TITLE
Fix WrapperEntity memory leak

### DIFF
--- a/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
+++ b/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
@@ -515,6 +515,7 @@ public class PacketNameTag {
             }
         });
 
+        perPlayerEntity.getEntities().values().forEach(WrapperEntity::remove);
         perPlayerEntity.getEntities().clear();
 
         plugin.getPacketManager().removePassenger(entityId);


### PR DESCRIPTION
When a player joins the server, a WrapperEntity object is created and spawned for them, and EntityLib retains a reference to it (in `EntityLib.getApi().getDefaultContainer().getEntities()`). However, when the player leaves, their WrapperEntity object is not removed from EntityLib's container, causing a memory leak.