### PR TITLE
Fix seeThrough when sneaking

### DIFF
--- a/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
+++ b/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
@@ -372,7 +372,11 @@ public class NameTagManager {
             }
 
             final boolean shadowed = nameTag.background().shadowed();
-            final boolean seeThrough = nameTag.background().seeThrough();
+            final boolean seeThrough;
+            if (!shiftSystemBlocked.getOrDefault(player.getUniqueId(), false) && packetNameTag.isSneaking())
+                seeThrough = false;
+            else
+                seeThrough = nameTag.background().seeThrough();
             final int backgroundColor = nameTag.background().getColor().asARGB();
 
             components.forEach((p, c) -> {


### PR DESCRIPTION
If the **seeThrough** setting is enabled, a player's nametag remains visible through blocks even while sneaking.
The nametag disappears briefly but reappears on the next refresh.
This PR fixes the issue