### PR TITLE
Use a separate entity for each line group

### DIFF
--- a/src/main/java/org/alexdev/unlimitednametags/UnlimitedNameTags.java
+++ b/src/main/java/org/alexdev/unlimitednametags/UnlimitedNameTags.java
@@ -277,9 +277,7 @@ public final class UnlimitedNameTags extends JavaPlugin {
         metrics.addCustomChart(new Metrics.AdvancedPie("nametags", () -> {
             final Map<String, Integer> map = Maps.newHashMap();
             configManager.getSettings().getNameTags().forEach((key, value) -> {
-                final int count = (int) nametagManager.getNameTags().values().stream()
-                        .filter(n -> n.getNameTag().equals(value))
-                        .count();
+                final int count = nametagManager.getNameTags().values().size();
                 map.put(key, count);
             });
             return map;

--- a/src/main/java/org/alexdev/unlimitednametags/commands/MainCommand.java
+++ b/src/main/java/org/alexdev/unlimitednametags/commands/MainCommand.java
@@ -62,7 +62,7 @@ public class MainCommand {
     @Command(name = "refresh", desc = "Refreshes the nametag of a player for you", usage = "refresh")
     @Require(value = "unt.refresh", message = "&cYou do not have permission to refresh the nametag")
     public void onRefresh(@Sender Player sender, Player target) {
-        plugin.getNametagManager().getPacketDisplayText(target).ifPresent(packetDisplayText -> {
+        plugin.getNametagManager().getPacketDisplayText(target).forEach(packetDisplayText -> {
             packetDisplayText.refreshForPlayer(sender);
         });
     }

--- a/src/main/java/org/alexdev/unlimitednametags/config/ConfigManager.java
+++ b/src/main/java/org/alexdev/unlimitednametags/config/ConfigManager.java
@@ -29,7 +29,7 @@ public class ConfigManager {
     private Settings settings;
     private boolean compiled;
 
-    public ConfigManager(@NotNull UnlimitedNameTags plugin) {
+    public ConfigManager(@NotNull final UnlimitedNameTags plugin) {
         this.plugin = plugin;
         this.loadUsage();
     }
@@ -39,7 +39,7 @@ public class ConfigManager {
              final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))
         ) {
             compiled = YamlConfiguration.loadConfiguration(reader).getBoolean("compiled", true);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -56,7 +56,7 @@ public class ConfigManager {
             );
             checkData();
             return Optional.empty();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             return Optional.of(e);
         }
     }
@@ -78,14 +78,16 @@ public class ConfigManager {
         final Map<String, Settings.NameTag> nameTags = Maps.newLinkedHashMap();
         boolean save = false;
 
-        for (Map.Entry<String, Settings.NameTag> entry : settings.getNameTags().entrySet()) {
+        for (final Map.Entry<String, Settings.NameTag> entry : settings.getNameTags().entrySet()) {
             final Settings.NameTag nameTag = entry.getValue();
-            if (nameTag.scale() <= 0) {
-                plugin.getLogger().warning("Nametag scale is less than or equal to 0");
-                nameTags.put(entry.getKey(), new Settings.NameTag(nameTag.permission(), nameTag.linesGroups(), nameTag.background(), 1f));
-                save = true;
-            } else {
-                nameTags.put(entry.getKey(), nameTag);
+            for (final Settings.LinesGroup linesGroup : nameTag.linesGroups()) {
+                if (linesGroup.scale() <= 0) {
+                    plugin.getLogger().warning("Nametag scale is less than or equal to 0");
+                    nameTags.put(entry.getKey(), new Settings.NameTag(nameTag.permission(), nameTag.linesGroups()));
+                    save = true;
+                } else {
+                    nameTags.put(entry.getKey(), nameTag);
+                }
             }
         }
 

--- a/src/main/java/org/alexdev/unlimitednametags/hook/TypeWriterListener.java
+++ b/src/main/java/org/alexdev/unlimitednametags/hook/TypeWriterListener.java
@@ -36,7 +36,7 @@ public class TypeWriterListener extends Hook implements Listener {
                             .filter(p -> p != null && p != event.getPlayer())
                             .collect(Collectors.toSet());
 
-                    plugin.getNametagManager().getPacketDisplayText(event.getPlayer()).ifPresent(display -> display.showToPlayers(viewers));
+                    plugin.getNametagManager().getPacketDisplayText(event.getPlayer()).forEach(display -> display.showToPlayers(viewers));
                 },
                 1);
         plugin.getTaskScheduler().runTaskLaterAsynchronously(

--- a/src/main/java/org/alexdev/unlimitednametags/listeners/PlayerListener.java
+++ b/src/main/java/org/alexdev/unlimitednametags/listeners/PlayerListener.java
@@ -173,7 +173,7 @@ public class PlayerListener implements PackSendHandler {
             return;
         }
 
-        plugin.getNametagManager().getPacketDisplayText(player).ifPresent(display -> {
+        plugin.getNametagManager().getPacketDisplayText(player).forEach(display -> {
             display.showToPlayer(event.getPlayer());
         });
     }
@@ -184,7 +184,7 @@ public class PlayerListener implements PackSendHandler {
             return;
         }
 
-        plugin.getNametagManager().getPacketDisplayText(player).ifPresent(display -> {
+        plugin.getNametagManager().getPacketDisplayText(player).forEach(display -> {
             display.hideFromPlayer(event.getPlayer());
         });
     }
@@ -216,7 +216,7 @@ public class PlayerListener implements PackSendHandler {
             return;
         }
 
-        plugin.getNametagManager().getPacketDisplayText(player).ifPresent(packetDisplayText -> {
+        plugin.getNametagManager().getPacketDisplayText(player).forEach(packetDisplayText -> {
             packetDisplayText.hideForOwner();
 
             plugin.getTaskScheduler().runTaskLaterAsynchronously(packetDisplayText::showForOwner, 5);

--- a/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
+++ b/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
@@ -396,6 +396,9 @@ public class NameTagManager {
         if (force && isScalePresent()) {
             packetNameTag.checkScale();
         }
+        if (force) {
+            packetNameTag.updateYOOffset();
+        }
 
         final boolean shadowed = linesGroup.background().shadowed();
         final boolean seeThrough = linesGroup.background().seeThrough();

--- a/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
+++ b/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
@@ -50,7 +50,7 @@ public class PacketNameTag {
     @Setter
     private boolean visible;
     @Setter
-    private Settings.NameTag nameTag;
+    private Settings.LinesGroup linesGroup;
     private float scale;
     private float offset;
     private float increasedOffset;
@@ -58,7 +58,7 @@ public class PacketNameTag {
     @Setter
     private boolean sneaking;
 
-    public PacketNameTag(@NotNull UnlimitedNameTags plugin, @NotNull Player owner, @NotNull Settings.NameTag nameTag) {
+    public PacketNameTag(@NotNull UnlimitedNameTags plugin, @NotNull Player owner, @NotNull Settings.LinesGroup linesGroup) {
         this.plugin = plugin;
         this.owner = owner;
         this.relationalCache = Maps.newConcurrentMap();
@@ -67,7 +67,7 @@ public class PacketNameTag {
         this.perPlayerEntity = new WrapperPerPlayerEntity(this.getBaseSupplier());
         this.blocked = Sets.newConcurrentHashSet();
         this.lastUpdate = System.currentTimeMillis();
-        this.nameTag = nameTag;
+        this.linesGroup = linesGroup;
         this.scale = plugin.getNametagManager().getScale(owner);
         this.setScale(scale);
     }
@@ -181,7 +181,7 @@ public class PacketNameTag {
     }
 
     public float getDefaultScale() {
-        return nameTag.scale();
+        return linesGroup.scale();
     }
 
     public boolean checkScale() {
@@ -231,7 +231,7 @@ public class PacketNameTag {
     }
 
     public void resetOffset(float offset) {
-        this.setTransformation(new Vector3f(0, offset + increasedOffset, 0));
+        this.setTransformation(new Vector3f(0, offset + increasedOffset + linesGroup.yOffset(), 0));
         this.offset = offset;
     }
 
@@ -401,7 +401,7 @@ public class PacketNameTag {
     }
 
     public void sendPassengersPacket(@NotNull User player) {
-        plugin.getPacketManager().sendPassengersPacket(player, this);
+        plugin.getNametagManager().sendPassengersPacket(player, getOwner());
     }
 
     public void sendPassengerPacketToViewers() {

--- a/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
+++ b/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
@@ -236,7 +236,7 @@ public class PacketNameTag {
     }
 
     public void updateYOOffset() {
-        this.setTransformation(new Vector3f(0, offset + increasedOffset, 0));
+        this.setTransformation(new Vector3f(0, offset + increasedOffset + linesGroup.yOffset(), 0));
     }
 
     public void setViewRange(float range) {
@@ -588,6 +588,7 @@ public class PacketNameTag {
         properties.put("backgroundColor", String.valueOf(meta.getBackgroundColor()));
         properties.put("transformation", meta.getTranslation().toString());
         properties.put("yOffset", String.valueOf(offset));
+        properties.put("lineGroupYOffset", String.valueOf(linesGroup.yOffset()));
         properties.put("scale", String.valueOf(meta.getScale()));
         properties.put("increasedOffset", String.valueOf(increasedOffset));
         properties.put("viewRange", String.valueOf(meta.getViewRange()));

--- a/src/main/java/org/alexdev/unlimitednametags/placeholders/PlaceholderManager.java
+++ b/src/main/java/org/alexdev/unlimitednametags/placeholders/PlaceholderManager.java
@@ -157,18 +157,19 @@ public class PlaceholderManager {
 
 
     @NotNull
-    public CompletableFuture<Map<Player, Component>> applyPlaceholders(@NotNull Player player, @NotNull List<Settings.LinesGroup> lines,
+    public CompletableFuture<Map<Player, Component>> applyPlaceholders(@NotNull Player player, @NotNull Settings.LinesGroup lines,
                                                                        @NotNull List<Player> relationalPlayers) {
         return getCheckedLines(player, lines).thenApplyAsync(strings -> createComponent(player, strings, relationalPlayers), executorService);
     }
 
     @NotNull
-    private CompletableFuture<List<String>> getCheckedLines(@NotNull Player player, @NotNull List<Settings.LinesGroup> lines) {
-        return CompletableFuture.supplyAsync(() -> lines.stream()
-                .filter(l -> l.modifiers() == null || l.modifiers().isEmpty() || l.modifiers().stream().allMatch(m -> m.isVisible(player, plugin)))
-                .map(Settings.LinesGroup::lines)
-                .flatMap(List::stream)
-                .toList(), executorService);
+    private CompletableFuture<List<String>> getCheckedLines(@NotNull Player player, @NotNull Settings.LinesGroup lines) {
+        return CompletableFuture.supplyAsync(() -> {
+            if(lines.modifiers() == null || lines.modifiers().isEmpty() || lines.modifiers().stream().allMatch(m -> m.isVisible(player, plugin))) {
+                return lines.lines();
+            }
+            return List.of();
+        }, executorService);
     }
 
     @NotNull


### PR DESCRIPTION
This PR changes the line group system to use a separate text display entity for each line group. This enables the creation of name tags with different backgrounds and scales.

It should be obvious that this PR changes quite a few things in the implementation and also contains a breaking API change that couldn't be reasonably avoided.

There still needs to be some testing done, and there are a few bugs left that need to be fixed regarding the y offset.