### PR TITLE
Add health-based nametag refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- **`settings.yml` schema v3**: TEXT `DisplayGroup.lines` is now a list of structured rows (`text` + optional `when`) instead of raw strings. This allows multiple conditional text lines to remain part of the same text display entity. Existing v2 YAML is migrated on load from `lines: ["foo"]` to `lines: [{text: "foo"}]`; Java API integrations that instantiate `Settings.DisplayGroup` must pass `List<Settings.NametagLine>`.
+
+### Added
+
+- **Per-line TEXT visibility**: each `NametagLine` can define `when` (JEXL, PlaceholderAPI-expanded) in addition to the group-level `DisplayGroup.when`. The group-level condition is evaluated first; then each line condition decides whether that line contributes to the final multi-line component.
+
 ## 2.0.0
 
 ### Breaking changes
@@ -28,7 +38,7 @@
 - **Through-wall nametag dimming** (optional): `obscuredNametagThroughWalls` uses the server’s line-of-sight check (`Player#hasLineOfSight`) on a configurable interval on the **main/region thread** (required for a correct ray trace). Viewers without clear sight to the nametag owner (within `obscuredNametagMaxDistance`) get `obscuredNametagOpacity` and forced text-display `seeThrough` so the tag can read through geometry. Tuning: `obscuredNametagCheckInterval` (ticks), `obscuredNametagMaxDistance`, `obscuredNametagOpacity` (same byte range as `sneakOpacity`).
 - **Cleaner YAML**: ConfigLib `outputNulls(false)` — optional fields are omitted instead of `key: null` (same for `advanced.yml`). Migrator dumps without null map entries.
 - **YAML robustness**: `placeholdersReplacements` entries are normalized before ConfigLib loads: YAML 1.1 parses unquoted `Yes`/`No` as booleans — they are rewritten as strings (`true`→`Yes`, `false`→`No`) to match `PlaceholderReplacement`. Prefer quoted keys in YAML, e.g. `placeholder: "Yes"`.
-- **`settings.yml` versioning**: root `configVersion` (see `SettingsConfigVersion.CURRENT`, **2** = structured nametags with **`displayGroups`**). On load/reload the plugin runs **`SettingsYamlMigrator`**: backs up to `settings.yml.backup-<epoch>.yml`, migrates **v1** (legacy flat `lines` / `background` / `scale`) → **`displayGroups`**, normalizes obsolete YAML key **`linesGroups`** → **`displayGroups`** when present, then rewrites the file if needed. Files without `configVersion` use legacy detection (flat `lines` on a tag).
+- **`settings.yml` versioning**: root `configVersion` was introduced (`2` = structured nametags with **`displayGroups`**). On load/reload the plugin runs **`SettingsYamlMigrator`**: backs up to `settings.yml.backup-<epoch>.yml`, migrates **v1** (legacy flat `lines` / `background` / `scale`) → **`displayGroups`**, normalizes obsolete YAML key **`linesGroups`** → **`displayGroups`** when present, then rewrites the file if needed. Files without `configVersion` use legacy detection (flat `lines` on a tag).
 - **`DisplayGroup.background` optional** in YAML: omit the key for a disabled transparent default (handy for item/block-only rows). Code uses `effectiveBackground()` when reading.
 - **Redundant default `background`**: A disabled **`type: integer`** block with RGB `0`, `opacity: 0`, and `shadowed: false` (any `seeThrough`) is treated like a missing key — `DisplayGroup`’s compact constructor clears it to `null`, and **`SettingsYamlMigrator`** removes that YAML block on load so the file stays minimal. The fallback **`effectiveBackground()`** for omitted rows now uses **`seeThrough: true`** (was `false`), matching typical “transparent text” configs.
 - **Implementation**: `PacketNameTag` is an abstract base class with package-private `TextPacketNameTag`, `ItemPacketNameTag`, and `BlockPacketNameTag`; use **`PacketNameTag.create(plugin, player, displayGroup)`** (not `new PacketNameTag(...)`) when instantiating from outside the packet package.
@@ -55,8 +65,16 @@ modifiers:
     value: "1000"
 ```
 
-**After (group-level `when` only):**
+**After (group-level `when`):**
 
 ```yaml
 when: "%vault_eco_balance% > 1000"
+```
+
+**After v3 (line-level `when` inside one text display):**
+
+```yaml
+lines:
+  - text: "Rich Player"
+    when: "%vault_eco_balance% > 1000"
 ```

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@
 
 **UnlimitedNameTags** is a **Paper-first** plugin (**1.20.1+**; Spigot **1.20.2+** also supported) that replaces vanilla name tags with **display entities** mounted on the player. Tags move smoothly with the player (client-side interpolation, not per-tick teleports).
 
-Each player can have several **stacked rows** (`displayGroups`): **TEXT**, **ITEM**, or **BLOCK**, each with its own scale, vertical offset, optional billboard, optional **`when`** (JEXL + PlaceholderAPI), and optional **animation**.
+Each player can have several **stacked rows** (`displayGroups`): **TEXT**, **ITEM**, or **BLOCK**, each with its own scale, vertical offset, optional billboard, optional **`when`** (JEXL + PlaceholderAPI), and optional **animation**. TEXT rows can also contain multiple structured `lines`, each with its own optional `when`, while still using one text display entity.
 
-> **Upgrading to 2.x?** See **[CHANGELOG.md](CHANGELOG.md)** for breaking changes (`displayGroups`, removal of `modifiers`, API return types, etc.).
+> **Upgrading to 3.x?** See **[CHANGELOG.md](CHANGELOG.md)** for breaking changes (`displayGroups`, structured `lines`, removal of `modifiers`, API return types, etc.).
 
 ---
 
@@ -65,12 +65,12 @@ Each player can have several **stacked rows** (`displayGroups`): **TEXT**, **ITE
 
 | | |
 |:---|:---|
-| **TEXT** | Multi-line Adventure components, per-row background / shadow / see-through |
+| **TEXT** | Multi-line Adventure components; each `lines` entry has `text` and optional `when` |
 | **ITEM** | `itemMaterial`, `itemDisplayMode`; **`lines` not used** — set material only |
 | **BLOCK** | `blockMaterial`; same as item — no text lines |
 | **Billboard** | Per-row **`billboard`** or global **`defaultBillboard`** (`CENTER`, `HORIZONTAL`, `VERTICAL`, `FIXED`) |
 | **Animations** | `rotate`, `bob`, `dvd_bounce`, `pulse_scale`, `wiggle`, `orbit`, plus **`custom`** via API; **`animationInterval`** / **`displayAnimationInterval`** / **`taskInterval`** control tick rate |
-| **Visibility** | Single **`when:`** per row (no `modifiers` in 2.x) |
+| **Visibility** | Group-level **`when:`** plus optional per-line **`when:`** for TEXT rows (no `modifiers`) |
 
 ### Config quality-of-life
 
@@ -78,7 +78,7 @@ Each player can have several **stacked rows** (`displayGroups`): **TEXT**, **ITE
 |:---|:---|
 | **Optional `background`** | Omit the key for a transparent default; redundant “disabled integer RGB 0” blocks are normalized away |
 | **Through-wall hint** *(optional)* | **`obscuredNametagThroughWalls`**: if a viewer has **no clear line of sight** to the player but is within range, the **text** row can appear **dimmer** so names behind walls are still noticeable. Tune **`obscuredNametagOpacity`**, **`obscuredNametagMaxDistance`**, **`obscuredNametagCheckInterval`**. *(TEXT only; sync task — uses `hasLineOfSight`.)* |
-| **Migration** | `configVersion` + **`SettingsYamlMigrator`** (backup, v1 → v2, YAML cleanup) |
+| **Migration** | `configVersion` + **`SettingsYamlMigrator`** (backup, v1 → v2 → v3, YAML cleanup) |
 
 ### Bedrock
 
@@ -113,6 +113,20 @@ Maven Central / publishing: **[MAVEN_CENTRAL_PUBLISHING.md](MAVEN_CENTRAL_PUBLIS
 1. Install **[PacketEvents](https://modrinth.com/plugin/packetevents)** and **UnlimitedNameTags** in `plugins/`.
 2. Restart the server.
 3. Edit **`plugins/UnlimitedNameTags/settings.yml`** (generated on first run).
+
+### Example — conditional text lines
+
+```yaml
+displayGroups:
+  - lines:
+      - text: "%luckperms_prefix%%player_name%"
+      - text: "&a%player_ping%ms"
+        when: "%player_ping% < 70"
+      - text: "&6%player_ping%ms"
+        when: "%player_ping% >= 70"
+    scale: 1.0
+    yOffset: 1.0
+```
 
 ### Example — item row + animation
 

--- a/api/src/main/java/org/alexdev/unlimitednametags/api/UNTAPI.java
+++ b/api/src/main/java/org/alexdev/unlimitednametags/api/UNTAPI.java
@@ -393,7 +393,7 @@ public class UNTAPI {
                 return group;
             }
             return new Settings.DisplayGroup(group.lines(), newBg, group.scale(), group.yOffset(), group.when(),
-                    group.displayType(), group.itemMaterial(), group.blockMaterial(), group.itemDisplayMode(), group.animation(), group.animationInterval(), group.billboard());
+                    group.relationalConditions(), group.displayType(), group.itemMaterial(), group.blockMaterial(), group.itemDisplayMode(), group.animation(), group.animationInterval(), group.billboard());
         });
 
         plugin.getNametagManager().setNametagOverride(player, modified);
@@ -418,7 +418,7 @@ public class UNTAPI {
                 return group;
             }
             return new Settings.DisplayGroup(group.lines(), newBg, group.scale(), group.yOffset(), group.when(),
-                    group.displayType(), group.itemMaterial(), group.blockMaterial(), group.itemDisplayMode(), group.animation(), group.animationInterval(), group.billboard());
+                    group.relationalConditions(), group.displayType(), group.itemMaterial(), group.blockMaterial(), group.itemDisplayMode(), group.animation(), group.animationInterval(), group.billboard());
         });
         plugin.getNametagManager().setNametagOverride(player, modified);
     }

--- a/api/src/main/java/org/alexdev/unlimitednametags/api/UntConditionalManager.java
+++ b/api/src/main/java/org/alexdev/unlimitednametags/api/UntConditionalManager.java
@@ -9,4 +9,10 @@ public interface UntConditionalManager {
      * Evaluates a JEXL boolean expression (after PlaceholderAPI when enabled).
      */
     boolean evaluateCondition(@NotNull String expression, @NotNull Player player);
+
+    /**
+     * Evaluates a JEXL boolean expression after {@link me.clip.placeholderapi.PlaceholderAPI#setRelationalPlaceholders(Player, Player, String)}
+     * with {@code viewer} as the target who sees and {@code owner} as the contextual player (nametag owner).
+     */
+    boolean evaluateCondition(@NotNull String expression, @NotNull Player viewer, @NotNull Player owner);
 }

--- a/api/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
+++ b/api/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
@@ -26,16 +26,16 @@ public class Settings {
 
     @Comment({
             "Schema version for settings.yml (managed by the plugin; do not lower).",
-            "1 = flat NameTag (lines on tag), 2 = displayGroups / DisplayGroup (current)."
+            "1 = flat NameTag, 2 = displayGroups with string lines, 3 = displayGroups with structured lines (current)."
     })
     private int configVersion = SettingsConfigVersion.CURRENT;
 
     private Map<String, NameTag> nameTags = new LinkedHashMap<>() {{
-        put("staffer", new NameTag("nametag.staffer", List.of(new DisplayGroup(List.of("%luckperms_prefix% %player_name% %luckperms_suffix%"),
-                new IntegerBackground(false, 255, 0, 0, 255, true, false), 1f, 1.0f, null, null, null, null, null, null, null, null))));
-        put("default", new NameTag("nametag.default", List.of(new DisplayGroup(List.of("%luckperms_prefix% %player_name% %luckperms_suffix%"),
-                        new IntegerBackground(false, 255, 0, 0, 255, true, false), 1f, 1.0f, null, null, null, null, null, null, null, null),
-                new DisplayGroup(List.of("Rich Player"), new HexBackground(false, "#ffffff", 255, false, false), 1f, 1.0f, "%vault_eco_balance% > 1000", null, null, null, null, null, null, null))));
+        put("staffer", new NameTag("nametag.staffer", List.of(new DisplayGroup(List.of(NametagLine.plain("%luckperms_prefix% %player_name% %luckperms_suffix%")),
+                new IntegerBackground(false, 255, 0, 0, 255, true, false), 1f, 1.0f, null, false, null, null, null, null, null, null, null))));
+        put("default", new NameTag("nametag.default", List.of(new DisplayGroup(List.of(NametagLine.plain("%luckperms_prefix% %player_name% %luckperms_suffix%")),
+                        new IntegerBackground(false, 255, 0, 0, 255, true, false), 1f, 1.0f, null, false, null, null, null, null, null, null, null),
+                new DisplayGroup(List.of(NametagLine.plain("Rich Player")), new HexBackground(false, "#ffffff", 255, false, false), 1f, 1.0f, "%vault_eco_balance% > 1000", false, null, null, null, null, null, null, null))));
     }};
 
     @Setter
@@ -66,6 +66,19 @@ public class Settings {
             "Similar to the background, the text rendering is discarded when it is less than 26. Defaults to -1, which represents 255 and is completely opaque."})
     private int sneakOpacity = 70;
     private float yOffset = 0.3f;
+
+    @Comment({
+            "When true, displayGroups are laid out as a compact vertical stack after placeholders are resolved.",
+            "Empty text groups and inactive groups do not reserve vertical space, while each group can still keep its own background/style.",
+            "Relational placeholders use the owner's resolved text for the shared stack position."
+    })
+    private boolean compactDisplayGroupStack = false;
+
+    @Comment({
+            "Estimated height, in blocks, consumed by one resolved text line when compactDisplayGroupStack is enabled.",
+            "This is an approximation because clients render font/resource-pack heights locally."
+    })
+    private float displayGroupLineHeightBlocks = 0.25f;
 
     @Comment({
             "Divided by 160 and sent to clients as the display entity view_range (vanilla default metadata = 1.0).",
@@ -187,25 +200,43 @@ public class Settings {
 
     }
 
+    public record NametagLine(@NotNull String text, @Nullable String when) {
+
+        public NametagLine {
+            text = text == null ? "" : text;
+        }
+
+        @NotNull
+        public static NametagLine plain(@NotNull final String text) {
+            return new NametagLine(text, null);
+        }
+    }
+
     /**
-     * One stacked nametag display (text, item, or block). Visibility is controlled only by optional {@code when} (JEXL).
+     * One stacked nametag display (text, item, or block). Visibility is controlled by optional group {@code when} (JEXL)
+     * and optional {@link NametagLine#when()} for each text line.
      * <p>
      * {@code background} may be omitted in YAML (null): same as a disabled transparent background — useful for {@link NametagDisplayType#ITEM}
      * and {@link NametagDisplayType#BLOCK} rows where text styling does not apply.
      * <p>
-     * <b>Lines</b>: used only for {@link NametagDisplayType#TEXT} (default). For {@link NametagDisplayType#ITEM} / {@link NametagDisplayType#BLOCK},
-     * {@code lines} in YAML are ignored; set {@code itemMaterial} / {@code blockMaterial} (required for content).
+     * <b>Lines</b>: used only for {@link NametagDisplayType#TEXT} (default). Each line is an object with {@code text}
+     * and optional {@code when}. For {@link NametagDisplayType#ITEM} / {@link NametagDisplayType#BLOCK}, {@code lines}
+     * in YAML are ignored; set {@code itemMaterial} / {@code blockMaterial} (required for content).
      * <p>
      * Optional {@code animation} (rotate, bob, dvd_bounce, pulse_scale, wiggle, orbit); optional {@code animation_interval}
      * (ticks between pose updates) overrides root {@code displayAnimationInterval} (or {@code taskInterval} when that is 0).
      * Optional {@code billboard} ({@code CENTER}, {@code HORIZONTAL}, {@code VERTICAL}, {@code FIXED}) overrides {@link Settings#getDefaultBillboard()} for this row only.
+     * <p>
+     * When {@code relationalConditions} is true, group and line {@code when} conditions and text for this row are evaluated with relational placeholders
+     * per viewer (viewer → owner). Requires PlaceholderAPI. Item/block rows still resolve {@code when} on the owner only.
      */
     public record DisplayGroup(
-            List<String> lines,
+            List<NametagLine> lines,
             @Nullable Background background,
             float scale,
             float yOffset,
             @Nullable String when,
+            boolean relationalConditions,
             @Nullable NametagDisplayType displayType,
             @Nullable String itemMaterial,
             @Nullable String blockMaterial,
@@ -219,7 +250,9 @@ public class Settings {
             if (resolved != NametagDisplayType.TEXT) {
                 lines = List.of();
             } else {
-                lines = lines == null ? List.of() : List.copyOf(lines);
+                lines = lines == null ? List.of() : lines.stream()
+                        .map(line -> line == null ? NametagLine.plain("") : line)
+                        .toList();
             }
             background = isRedundantOmittedStyleIntegerBackground(background) ? null : background;
         }
@@ -278,16 +311,16 @@ public class Settings {
         }
 
         public DisplayGroup withBackground(@NotNull Background background) {
-            return new DisplayGroup(lines, background, scale, yOffset, when, displayType, itemMaterial, blockMaterial, itemDisplayMode, animation, animationInterval, billboard);
+            return new DisplayGroup(lines, background, scale, yOffset, when, relationalConditions, displayType, itemMaterial, blockMaterial, itemDisplayMode, animation, animationInterval, billboard);
         }
 
         public DisplayGroup withScale(float scale) {
-            return new DisplayGroup(lines, background, scale, yOffset, when, displayType, itemMaterial, blockMaterial, itemDisplayMode, animation, animationInterval, billboard);
+            return new DisplayGroup(lines, background, scale, yOffset, when, relationalConditions, displayType, itemMaterial, blockMaterial, itemDisplayMode, animation, animationInterval, billboard);
         }
 
         @NotNull
         public DisplayGroup withAnimation(@Nullable DisplayAnimation animation) {
-            return new DisplayGroup(lines, background, scale, yOffset, when, displayType, itemMaterial, blockMaterial, itemDisplayMode, animation, animationInterval, billboard);
+            return new DisplayGroup(lines, background, scale, yOffset, when, relationalConditions, displayType, itemMaterial, blockMaterial, itemDisplayMode, animation, animationInterval, billboard);
         }
 
     }

--- a/api/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
+++ b/api/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
@@ -108,6 +108,9 @@ public class Settings {
     @Comment("When true, listens for health update packets and refreshes the nametag.")
     private boolean healthRefresh = true;
 
+    @Comment("If healthRefresh is enabled, the nametag will always refresh below this health value, regardless of rounding.")
+    private float healthRefreshAlwaysUpdateBelow = 2.0f;
+
     @Comment("Whether to see the NameTag of a user only while pointing at them")
     private boolean showWhileLooking = false;
 

--- a/api/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
+++ b/api/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
@@ -91,7 +91,7 @@ public class Settings {
     @Comment("""
             Which text formatter to use (MINIMESSAGE, MINEDOWN, LEGACY or UNIVERSAL)\s
             Take note that UNIVERSAL is the most resource intensive but it supports all formatting options (except for MINEDOWN)\s
-            
+
             (&x&0&8&4&c&f&bc LEGACY OF LEGACY - &#084cfbc LEGACY - &#084cfbc& MINEDOWN - <color:#084cfbc> MINIMESSAGE)""")
     @Setter
     private Formatter format = Formatter.MINIMESSAGE;
@@ -104,6 +104,9 @@ public class Settings {
     private boolean forceDisableDefaultNameTag = false;
 
     private boolean removeEmptyLines = true;
+
+    @Comment("When true, listens for health update packets and refreshes the nametag.")
+    private boolean healthRefresh = true;
 
     @Comment("Whether to see the NameTag of a user only while pointing at them")
     private boolean showWhileLooking = false;

--- a/api/src/main/java/org/alexdev/unlimitednametags/config/SettingsConfigVersion.java
+++ b/api/src/main/java/org/alexdev/unlimitednametags/config/SettingsConfigVersion.java
@@ -9,9 +9,14 @@ public final class SettingsConfigVersion {
     }
 
     /**
-     * Latest schema ({@code displayGroups}, {@link Settings.DisplayGroup}, {@code displayType}, etc.).
+     * Latest schema ({@code displayGroups}, {@link Settings.DisplayGroup}, structured {@code lines}, etc.).
      */
-    public static final int CURRENT = 2;
+    public static final int CURRENT = 3;
+
+    /**
+     * Display groups with {@code lines} represented as raw strings.
+     */
+    public static final int STRING_LINE_DISPLAY_GROUPS = 2;
 
     /**
      * Legacy: each {@code NameTag} had top-level {@code lines}, {@code background}, {@code scale} (and optional {@code yOffset}).

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/commands/UntBrigadierCommands.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/commands/UntBrigadierCommands.java
@@ -103,6 +103,7 @@ public final class UntBrigadierCommands {
                     plugin.getConfigManager().reload();
                     plugin.getNametagManager().reload();
                     plugin.getPlaceholderManager().reload();
+                    plugin.getPacketEventsListener().reload();
                     msg(plugin, ctx.getSource().getSender(), "<green>UnlimitedNameTags has been reloaded!</green>");
                     return Command.SINGLE_SUCCESS;
                 });

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/config/SettingsYamlMigrator.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/config/SettingsYamlMigrator.java
@@ -48,19 +48,19 @@ public final class SettingsYamlMigrator {
 
         int declared = parseDeclaredVersion(root);
         boolean changed = false;
-        if (declared == 3) {
-            log.info("settings.yml had unreleased configVersion 3; normalized to " + SettingsConfigVersion.CURRENT + ".");
-            root.put("configVersion", SettingsConfigVersion.CURRENT);
-            declared = SettingsConfigVersion.CURRENT;
-            changed = true;
-        }
-
         final boolean legacy = hasLegacyFlatNameTags(root);
+        final boolean stringLineDisplayGroups = hasStringLineDisplayGroups(root);
         final int from;
-        if (declared > 0) {
+        if (declared == SettingsConfigVersion.CURRENT && stringLineDisplayGroups) {
+            log.info("settings.yml has configVersion " + SettingsConfigVersion.CURRENT
+                    + " but still uses v2 string lines; migrating lines to structured rows.");
+            from = SettingsConfigVersion.STRING_LINE_DISPLAY_GROUPS;
+        } else if (declared > 0) {
             from = declared;
         } else if (legacy) {
             from = SettingsConfigVersion.LEGACY_FLAT_NAMETAG;
+        } else if (stringLineDisplayGroups) {
+            from = SettingsConfigVersion.STRING_LINE_DISPLAY_GROUPS;
         } else {
             from = SettingsConfigVersion.CURRENT;
         }
@@ -71,16 +71,19 @@ public final class SettingsYamlMigrator {
             return;
         }
 
+        changed |= renameObsoleteLinesGroupsKey(root, log);
         changed |= sanitizePlaceholdersReplacements(root, log);
         changed |= stripObsoleteDisplayGroupFields(root, log);
         changed |= stripRedundantDisplayBackgrounds(root, log);
-        changed |= renameObsoleteLinesGroupsKey(root, log);
         for (int v = from; v < SettingsConfigVersion.CURRENT; v++) {
             switch (v) {
                 case 1 -> changed |= migrateV1ToV2(root, log);
+                case 2 -> changed |= migrateV2ToV3(root, log);
                 default -> throw new IllegalStateException("Missing settings migrator from v" + v + " to v" + (v + 1));
             }
         }
+        changed |= stripObsoleteDisplayGroupFields(root, log);
+        changed |= stripRedundantDisplayBackgrounds(root, log);
 
         final Object currentDeclared = root.get("configVersion");
         final int currentInFile = currentDeclared instanceof Number n ? n.intValue() : 0;
@@ -185,6 +188,37 @@ public final class SettingsYamlMigrator {
                         && !tag.containsKey("linesGroups")
                         && !tag.containsKey("displayGroups")) {
                     return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasStringLineDisplayGroups(Map<String, Object> root) {
+        final Object nameTags = root.get("nameTags");
+        if (!(nameTags instanceof Map<?, ?> nt)) {
+            return false;
+        }
+        for (Object raw : nt.values()) {
+            if (!(raw instanceof Map<?, ?> tag)) {
+                continue;
+            }
+            final Object groupsObj = tag.containsKey("displayGroups") ? tag.get("displayGroups") : tag.get("linesGroups");
+            if (!(groupsObj instanceof List<?> groups)) {
+                continue;
+            }
+            for (Object groupObj : groups) {
+                if (!(groupObj instanceof Map<?, ?> group)) {
+                    continue;
+                }
+                final Object linesObj = group.get("lines");
+                if (!(linesObj instanceof List<?> lines)) {
+                    continue;
+                }
+                for (Object line : lines) {
+                    if (!(line instanceof Map<?, ?>)) {
+                        return true;
+                    }
                 }
             }
         }
@@ -413,6 +447,81 @@ public final class SettingsYamlMigrator {
 
             log.info("Migrated NameTag '" + key + "' from flat lines (v1) to displayGroups.");
             any = true;
+        }
+        return any;
+    }
+
+    /**
+     * Converts v2 text rows from {@code lines: [string, ...]} to structured rows:
+     * {@code lines: [{text: string}, ...]}. This keeps one text display per display group while allowing per-line metadata.
+     */
+    @SuppressWarnings("unchecked")
+    private static boolean migrateV2ToV3(Map<String, Object> root, Logger log) {
+        final Object nameTags = root.get("nameTags");
+        if (!(nameTags instanceof Map<?, ?> nt)) {
+            return false;
+        }
+        boolean any = false;
+        for (Map.Entry<?, ?> entry : nt.entrySet()) {
+            final String tagKey = String.valueOf(entry.getKey());
+            final Object rawTag = entry.getValue();
+            if (!(rawTag instanceof Map)) {
+                continue;
+            }
+            final Map<String, Object> tag = (Map<String, Object>) rawTag;
+            final Object dg = tag.get("displayGroups");
+            if (!(dg instanceof List<?> groups)) {
+                continue;
+            }
+            for (int groupIndex = 0; groupIndex < groups.size(); groupIndex++) {
+                final Object rawGroup = groups.get(groupIndex);
+                if (!(rawGroup instanceof Map)) {
+                    continue;
+                }
+                final Map<String, Object> group = (Map<String, Object>) rawGroup;
+                final Object linesObj = group.get("lines");
+                if (!(linesObj instanceof List<?> rawLines)) {
+                    continue;
+                }
+
+                final List<Object> migratedLines = new ArrayList<>(rawLines.size());
+                boolean groupChanged = false;
+                for (Object rawLine : rawLines) {
+                    if (rawLine instanceof Map<?, ?> existingLine) {
+                        final Map<String, Object> line = new LinkedHashMap<>();
+                        for (Map.Entry<?, ?> lineEntry : existingLine.entrySet()) {
+                            line.put(String.valueOf(lineEntry.getKey()), lineEntry.getValue());
+                        }
+                        if (!line.containsKey("text") && line.containsKey("line")) {
+                            line.put("text", line.remove("line"));
+                            groupChanged = true;
+                        }
+                        if (!line.containsKey("text")) {
+                            log.warning("NameTag '" + tagKey + "' displayGroups[" + groupIndex + "] has a structured line without 'text'.");
+                            line.put("text", "");
+                            groupChanged = true;
+                        } else if (!(line.get("text") instanceof String)) {
+                            line.put("text", String.valueOf(line.get("text")));
+                            groupChanged = true;
+                        }
+                        migratedLines.add(line);
+                        continue;
+                    }
+
+                    final Map<String, Object> line = new LinkedHashMap<>();
+                    line.put("text", rawLine == null ? "" : String.valueOf(rawLine));
+                    migratedLines.add(line);
+                    groupChanged = true;
+                }
+
+                if (groupChanged) {
+                    group.put("lines", migratedLines);
+                    any = true;
+                }
+            }
+        }
+        if (any) {
+            log.info("Migrated displayGroups lines from raw strings (v2) to structured text rows (v3).");
         }
         return any;
     }

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
@@ -14,6 +14,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerCa
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetPassengers;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTeams;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateHealth;
 import com.google.common.collect.Maps;
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
 import org.alexdev.unlimitednametags.data.TeamData;
@@ -27,10 +28,12 @@ public class PacketEventsListener extends PacketListenerAbstract {
 
     private final UnlimitedNameTags plugin;
     private final Map<UUID, Map<String, TeamData>> teams;
+    private final Map<UUID, Integer> healthRounded;
 
     public PacketEventsListener(UnlimitedNameTags plugin) {
         this.plugin = plugin;
         this.teams = Maps.newConcurrentMap();
+        this.healthRounded = Maps.newConcurrentMap();
     }
 
     public void onEnable() {
@@ -51,6 +54,8 @@ public class PacketEventsListener extends PacketListenerAbstract {
             handleMetaData(event);
         } else if (event.getPacketType() == PacketType.Play.Server.CAMERA) {
             handleCamera(event);
+        } else if (event.getPacketType() == PacketType.Play.Server.UPDATE_HEALTH) {
+            handleHealthUpdate(event);
         }
     }
 
@@ -69,6 +74,22 @@ public class PacketEventsListener extends PacketListenerAbstract {
         } else {
             plugin.getNametagManager().getPacketDisplayText(player).forEach(PacketNameTag::hideForOwner);
         }
+    }
+
+    private void handleHealthUpdate(@NotNull PacketSendEvent event) {
+        if (!plugin.getConfigManager().getSettings().isHealthRefresh()) {
+            return;
+        }
+        if (!(event.getPlayer() instanceof Player player)) {
+            return;
+        }
+        final WrapperPlayServerUpdateHealth packet = new WrapperPlayServerUpdateHealth(event);
+        final int roundedHealth = (int) packet.getHealth();
+        final Integer prev = healthRounded.put(player.getUniqueId(), roundedHealth);
+        if (prev != null && prev == roundedHealth) {
+            return;
+        }
+        plugin.getNametagManager().refresh(player, false);
     }
 
     @Override
@@ -256,6 +277,7 @@ public class PacketEventsListener extends PacketListenerAbstract {
 
     public void removePlayerData(@NotNull Player player) {
         teams.remove(player.getUniqueId());
+        healthRounded.remove(player.getUniqueId());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -291,6 +313,7 @@ public class PacketEventsListener extends PacketListenerAbstract {
     }
 
     public void onDisable() {
+        healthRounded.clear();
         PacketEvents.getAPI().getEventManager().unregisterListener(this);
     }
 }

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
@@ -84,11 +84,19 @@ public class PacketEventsListener extends PacketListenerAbstract {
             return;
         }
         final WrapperPlayServerUpdateHealth packet = new WrapperPlayServerUpdateHealth(event);
-        final int roundedHealth = (int) packet.getHealth();
-        final Integer prev = healthRounded.put(player.getUniqueId(), roundedHealth);
+        final float health = packet.getHealth();
+        final int roundedHealth = (int) health;
+        final UUID uuid = player.getUniqueId();
+        if (health < 1.0f) {
+            healthRounded.put(uuid, roundedHealth);
+            plugin.getNametagManager().refresh(player, false);
+            return;
+        }
+        final Integer prev = healthRounded.get(uuid);
         if (prev != null && prev == roundedHealth) {
             return;
         }
+        healthRounded.put(uuid, roundedHealth);
         plugin.getNametagManager().refresh(player, false);
     }
 

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
@@ -29,11 +29,13 @@ public class PacketEventsListener extends PacketListenerAbstract {
     private final UnlimitedNameTags plugin;
     private final Map<UUID, Map<String, TeamData>> teams;
     private final Map<UUID, Integer> healthRounded;
+    private float alwaysUpdateBelow;
 
     public PacketEventsListener(UnlimitedNameTags plugin) {
         this.plugin = plugin;
         this.teams = Maps.newConcurrentMap();
         this.healthRounded = Maps.newConcurrentMap();
+        this.alwaysUpdateBelow = plugin.getConfigManager().getSettings().getHealthRefreshAlwaysUpdateBelow();
     }
 
     public void onEnable() {
@@ -87,7 +89,7 @@ public class PacketEventsListener extends PacketListenerAbstract {
         final float health = packet.getHealth();
         final int roundedHealth = (int) health;
         final UUID uuid = player.getUniqueId();
-        if (health < 1.0f) {
+        if (health < alwaysUpdateBelow) {
             healthRounded.put(uuid, roundedHealth);
             plugin.getNametagManager().refresh(player, false);
             return;
@@ -318,6 +320,10 @@ public class PacketEventsListener extends PacketListenerAbstract {
 
     public boolean existsPlayer(@NotNull String name) {
         return plugin.getPlayerListener().getPlayerNameId().containsKey(name);
+    }
+
+    public void reload() {
+        this.alwaysUpdateBelow = plugin.getConfigManager().getSettings().getHealthRefreshAlwaysUpdateBelow();
     }
 
     public void onDisable() {

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/nametags/ConditionalManager.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/nametags/ConditionalManager.java
@@ -54,6 +54,24 @@ public class ConditionalManager implements UntConditionalManager {
                 PlaceholderAPI.setPlaceholders(player, trimmed) :
                 trimmed;
 
+        return evaluateExpandedJexl(entireExpression);
+    }
+
+    @Override
+    public boolean evaluateCondition(@NotNull String expression, @NotNull Player viewer, @NotNull Player owner) {
+        final String trimmed = expression.trim();
+        if (trimmed.isEmpty()) {
+            return false;
+        }
+
+        final String entireExpression = plugin.getPlaceholderManager().getPapiManager().isPapiEnabled() ?
+                PlaceholderAPI.setRelationalPlaceholders(viewer, owner, trimmed) :
+                trimmed;
+
+        return evaluateExpandedJexl(entireExpression);
+    }
+
+    private boolean evaluateExpandedJexl(@NotNull String entireExpression) {
         final Object cachedVal = cachedExpressions.get(entireExpression);
         if (cachedVal instanceof Boolean b) {
             return b;

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
@@ -10,6 +10,7 @@ import com.google.common.collect.Sets;
 import lombok.Getter;
 import lombok.Setter;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.TextColor;
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
 import org.alexdev.unlimitednametags.api.UntNametagManager;
@@ -29,6 +30,7 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,6 +40,9 @@ import java.util.stream.Collectors;
 
 @Getter
 public class NameTagManager implements UntNametagManager {
+
+    private static final float COMPACT_ITEM_DISPLAY_HEIGHT_BLOCKS = 0.35f;
+    private static final float COMPACT_BLOCK_DISPLAY_HEIGHT_BLOCKS = 0.5f;
 
     private final UnlimitedNameTags plugin;
     private final ConcurrentHashMap<UUID, CopyOnWriteArrayList<PacketNameTag>> nameTags;
@@ -58,6 +63,15 @@ public class NameTagManager implements UntNametagManager {
     @Setter
     private boolean debug = false;
     private final Attribute scaleAttribute;
+
+    private record ResolvedDisplayRow(
+            int index,
+            @NotNull Settings.DisplayGroup displayGroup,
+            @NotNull PacketNameTag display,
+            @NotNull List<Player> relationalPlayers,
+            @NotNull Map<Player, Component> components,
+            Component ownerComponent) {
+    }
 
     public NameTagManager(@NotNull UnlimitedNameTags plugin) {
         this.plugin = plugin;
@@ -560,27 +574,31 @@ public class NameTagManager implements UntNametagManager {
         final int rowCount = nametag.displayGroups().size();
         pendingRowCreations.put(player.getUniqueId(), new AtomicInteger(rowCount));
 
+        final List<CompletableFuture<ResolvedDisplayRow>> futures = new ArrayList<>(rowCount);
         for (int i = 0; i < rowCount; i++) {
             final Settings.DisplayGroup displayGroup = nametag.displayGroups().get(i);
             final PacketNameTag display = createdTags.get(i);
-            plugin.getPlaceholderManager().applyPlaceholders(player, displayGroup, List.of(player))
-                    .thenAccept(lines -> {
-                        final Component resolved = lines.get(player);
-                        if (resolved == null) {
-                            plugin.getLogger().warning(
-                                    "No nametag component for owner " + player.getName() + "; skipping display row.");
-                            finishRowCreation(player.getUniqueId());
-                            return;
-                        }
-                        loadDisplay(player, resolved, displayGroup, display);
-                    })
-                    .exceptionally(throwable -> {
-                        plugin.getLogger().log(java.util.logging.Level.SEVERE,
-                                "Failed to create nametag for " + player.getName(), throwable);
-                        finishRowCreation(player.getUniqueId());
-                        return null;
-                    });
+            futures.add(resolveDisplayRow(player, i, displayGroup, display, List.of(player), "create"));
         }
+
+        CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).thenRun(() -> {
+            final List<ResolvedDisplayRow> rows = collectResolvedRows(futures);
+            for (ResolvedDisplayRow row : rows) {
+                final Component resolved = row.ownerComponent();
+                if (resolved == null) {
+                    plugin.getLogger().warning(
+                            "No nametag component for owner " + player.getName() + "; skipping display row.");
+                    finishRowCreation(player.getUniqueId());
+                    continue;
+                }
+                loadDisplay(player, resolved, row.displayGroup(), row.display());
+            }
+            applyDisplayGroupStackLayout(player, rows);
+            final int missingRows = rowCount - rows.size();
+            for (int i = 0; i < missingRows; i++) {
+                finishRowCreation(player.getUniqueId());
+            }
+        });
 
     }
     public void refresh(@NotNull Player player, boolean force) {
@@ -597,6 +615,7 @@ public class NameTagManager implements UntNametagManager {
             return;
         }
 
+        final List<CompletableFuture<ResolvedDisplayRow>> futures = new ArrayList<>(nametag.displayGroups().size());
         for (int i = 0; i < nametag.displayGroups().size(); i++) {
             final Settings.DisplayGroup displayGroup = nametag.displayGroups().get(i);
             replaceDisplayIfNeeded(player, i, displayGroup);
@@ -619,14 +638,13 @@ public class NameTagManager implements UntNametagManager {
 
             final List<Player> relationalPlayers = relationalPlayersForRefresh(player, display);
 
-            plugin.getPlaceholderManager().applyPlaceholders(player, displayGroup, relationalPlayers)
-                    .thenAccept(lines -> editDisplay(display, lines, displayGroup, force))
-                    .exceptionally(throwable -> {
-                        plugin.getLogger().log(java.util.logging.Level.SEVERE,
-                                "Failed to edit nametag for " + player.getName(), throwable);
-                        return null;
-                    });
+            futures.add(resolveDisplayRow(player, i, displayGroup, display, relationalPlayers, "edit"));
         }
+        CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).thenRun(() -> {
+            final List<ResolvedDisplayRow> rows = collectResolvedRows(futures);
+            rows.forEach(row -> editDisplay(row.display(), row.components(), row.displayGroup(), force));
+            applyDisplayGroupStackLayout(player, rows);
+        });
     }
 
     private void updateLineCount(Player player, Settings.NameTag nametag) {
@@ -817,6 +835,229 @@ public class NameTagManager implements UntNametagManager {
         handleVanish(player, neu);
         list.set(index, neu);
         entityIdToDisplay.put(neu.getEntityId(), neu);
+    }
+
+    @NotNull
+    private CompletableFuture<ResolvedDisplayRow> resolveDisplayRow(@NotNull Player player,
+            int index,
+            @NotNull Settings.DisplayGroup displayGroup,
+            @NotNull PacketNameTag display,
+            @NotNull List<Player> relationalPlayers,
+            @NotNull String action) {
+        final List<Player> layoutPlayers = relationalPlayersWithOwner(player, relationalPlayers);
+        return plugin.getPlaceholderManager().applyPlaceholders(player, displayGroup, layoutPlayers)
+                .thenApply(lines -> new ResolvedDisplayRow(index, displayGroup, display, layoutPlayers, lines, lines.get(player)))
+                .exceptionally(throwable -> {
+                    plugin.getLogger().log(java.util.logging.Level.SEVERE,
+                            "Failed to " + action + " nametag for " + player.getName(), throwable);
+                    return null;
+                });
+    }
+
+    @NotNull
+    private List<Player> relationalPlayersWithOwner(@NotNull Player owner, @NotNull List<Player> relationalPlayers) {
+        if (relationalPlayers.contains(owner)) {
+            return relationalPlayers;
+        }
+        final ArrayList<Player> withOwner = new ArrayList<>(relationalPlayers.size() + 1);
+        withOwner.add(owner);
+        withOwner.addAll(relationalPlayers);
+        return withOwner;
+    }
+
+    @NotNull
+    private List<ResolvedDisplayRow> collectResolvedRows(@NotNull List<CompletableFuture<ResolvedDisplayRow>> futures) {
+        return futures.stream()
+                .map(CompletableFuture::join)
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparingInt(ResolvedDisplayRow::index))
+                .toList();
+    }
+
+    private void applyDisplayGroupStackLayout(@NotNull Player player, @NotNull List<ResolvedDisplayRow> rows) {
+        final Settings settings = plugin.getConfigManager().getSettings();
+        final float helmetExtraOffset = plugin.getPlaceholderManager().computeHelmetExtraOffset(player);
+        final float globalYOffset = settings.getYOffset();
+
+        if (!settings.isCompactDisplayGroupStack()) {
+            rows.forEach(row -> {
+                row.display().clearCompactStackYOffset();
+                row.display().setHelmetExtraOffset(helmetExtraOffset);
+            });
+            return;
+        }
+
+        final boolean perViewerNeeded = rows.stream().anyMatch(r -> r.displayGroup().relationalConditions());
+        final LinkedHashSet<Player> viewersUnion = new LinkedHashSet<>();
+        for (ResolvedDisplayRow row : rows) {
+            viewersUnion.addAll(row.relationalPlayers());
+        }
+
+        if (!perViewerNeeded) {
+            rows.forEach(row -> {
+                row.display().clearPerViewerStackLayout();
+                row.display().setHelmetExtraOffset(helmetExtraOffset);
+            });
+            final float lineHeight = Math.max(0.01f, settings.getDisplayGroupLineHeightBlocks());
+            boolean hasVisibleRow = false;
+            float nextYOffset = 0f;
+
+            for (ResolvedDisplayRow row : rows) {
+                if (!isCompactStackVisible(player, row)) {
+                    row.display().setCompactStackYOffset(hasVisibleRow ? nextYOffset : row.displayGroup().yOffset(), false);
+                    continue;
+                }
+
+                final float rowYOffset = hasVisibleRow ? nextYOffset : row.displayGroup().yOffset();
+                row.display().setCompactStackYOffset(rowYOffset, !hasVisibleRow);
+                nextYOffset = rowYOffset + estimateDisplayGroupHeight(row, lineHeight);
+                hasVisibleRow = true;
+            }
+            return;
+        }
+
+        rows.forEach(row -> {
+            row.display().clearCompactStackYOffset();
+            row.display().setHelmetExtraOffset(0f);
+        });
+
+        final float lineHeight = Math.max(0.01f, settings.getDisplayGroupLineHeightBlocks());
+        final List<Map<UUID, Float>> yByRow = new ArrayList<>(rows.size());
+        for (int i = 0; i < rows.size(); i++) {
+            yByRow.add(new HashMap<>());
+        }
+
+        for (Player viewer : viewersUnion) {
+            boolean hasVisibleRow = false;
+            float nextYOffset = 0f;
+            for (int i = 0; i < rows.size(); i++) {
+                final ResolvedDisplayRow row = rows.get(i);
+                final PacketNameTag display = row.display();
+                final float inc = stackIncreasedOffset(display);
+                final boolean visible = isCompactStackVisibleForViewer(player, viewer, row);
+                final float rowCompactY;
+                final boolean helmetForRow;
+                if (!visible) {
+                    rowCompactY = hasVisibleRow ? nextYOffset : row.displayGroup().yOffset();
+                    helmetForRow = false;
+                } else {
+                    rowCompactY = hasVisibleRow ? nextYOffset : row.displayGroup().yOffset();
+                    helmetForRow = !hasVisibleRow;
+                    nextYOffset = rowCompactY + estimateDisplayGroupHeightForViewer(player, viewer, row, lineHeight);
+                    hasVisibleRow = true;
+                }
+                final float baseY = globalYOffset + inc + rowCompactY + (helmetForRow ? helmetExtraOffset : 0f);
+                yByRow.get(i).put(viewer.getUniqueId(), baseY);
+            }
+        }
+
+        for (int i = 0; i < rows.size(); i++) {
+            rows.get(i).display().setPerViewerStackBaseY(yByRow.get(i));
+        }
+    }
+
+    private static float stackIncreasedOffset(@NotNull PacketNameTag display) {
+        final float sc = display.getScale();
+        return sc > 1f ? sc / 5f : 0f;
+    }
+
+    private boolean isCompactStackVisibleForViewer(
+            @NotNull Player owner, @NotNull Player viewer, @NotNull ResolvedDisplayRow row) {
+        final boolean relationalText = row.displayGroup().relationalConditions()
+                && row.displayGroup().resolvedDisplayType() == NametagDisplayType.TEXT;
+        if (!plugin.getPlaceholderManager().isDisplayGroupActive(owner, row.displayGroup(),
+                relationalText ? viewer : null)) {
+            return false;
+        }
+
+        return switch (row.displayGroup().resolvedDisplayType()) {
+            case TEXT -> hasRenderableText(row.components().get(viewer));
+            case ITEM -> isMaterialVisible(owner, row.displayGroup().itemMaterial(), true);
+            case BLOCK -> isMaterialVisible(owner, row.displayGroup().blockMaterial(), false);
+        };
+    }
+
+    private float estimateDisplayGroupHeightForViewer(
+            @NotNull Player owner, @NotNull Player viewer, @NotNull ResolvedDisplayRow row, float lineHeight) {
+        final float scale = row.display().getScale();
+        return switch (row.displayGroup().resolvedDisplayType()) {
+            case TEXT -> Math.max(1, estimateTextLineCount(row.components().get(viewer))) * lineHeight * scale;
+            case ITEM -> COMPACT_ITEM_DISPLAY_HEIGHT_BLOCKS * scale;
+            case BLOCK -> COMPACT_BLOCK_DISPLAY_HEIGHT_BLOCKS * scale;
+        };
+    }
+
+    private boolean isCompactStackVisible(@NotNull Player player, @NotNull ResolvedDisplayRow row) {
+        if (!plugin.getPlaceholderManager().isDisplayGroupActive(player, row.displayGroup())) {
+            return false;
+        }
+
+        return switch (row.displayGroup().resolvedDisplayType()) {
+            case TEXT -> hasRenderableText(row.ownerComponent());
+            case ITEM -> isMaterialVisible(player, row.displayGroup().itemMaterial(), true);
+            case BLOCK -> isMaterialVisible(player, row.displayGroup().blockMaterial(), false);
+        };
+    }
+
+    private boolean isMaterialVisible(@NotNull Player player, String rawMaterial, boolean item) {
+        String raw = rawMaterial;
+        if (raw == null || raw.isBlank()) {
+            raw = "STONE";
+        }
+        final String expanded = plugin.getPlaceholderManager().expandForOwner(player, raw).trim();
+        final Material material = Material.matchMaterial(expanded, false);
+        if (material == null) {
+            return false;
+        }
+        return item ? material.isItem() : material.isBlock() && !material.isAir();
+    }
+
+    private float estimateDisplayGroupHeight(@NotNull ResolvedDisplayRow row, float lineHeight) {
+        final float scale = row.display().getScale();
+        return switch (row.displayGroup().resolvedDisplayType()) {
+            case TEXT -> Math.max(1, estimateTextLineCount(row.ownerComponent())) * lineHeight * scale;
+            case ITEM -> COMPACT_ITEM_DISPLAY_HEIGHT_BLOCKS * scale;
+            case BLOCK -> COMPACT_BLOCK_DISPLAY_HEIGHT_BLOCKS * scale;
+        };
+    }
+
+    private int estimateTextLineCount(Component component) {
+        if (!hasRenderableText(component)) {
+            return 0;
+        }
+        return Math.max(1, countNewlines(component) + 1);
+    }
+
+    private boolean hasRenderableText(Component component) {
+        if (component == null) {
+            return false;
+        }
+        if (component instanceof TextComponent textComponent) {
+            if (textComponent.content().chars().anyMatch(c -> c != '\n' && c != '\r')) {
+                return true;
+            }
+            return component.children().stream().anyMatch(this::hasRenderableText);
+        }
+        return !component.equals(Component.empty()) || component.children().stream().anyMatch(this::hasRenderableText);
+    }
+
+    private int countNewlines(Component component) {
+        if (component == null) {
+            return 0;
+        }
+        int count = 0;
+        if (component instanceof TextComponent textComponent) {
+            final String content = textComponent.content();
+            for (int i = 0; i < content.length(); i++) {
+                if (content.charAt(i) == '\n') {
+                    count++;
+                }
+            }
+        }
+        for (Component child : component.children()) {
+            count += countNewlines(child);
+        }
+        return count;
     }
 
     @NotNull
@@ -1178,6 +1419,7 @@ public class NameTagManager implements UntNametagManager {
             return;
         }
 
+        final List<CompletableFuture<ResolvedDisplayRow>> futures = new ArrayList<>(nameTag.displayGroups().size());
         for (int i = 0; i < nameTag.displayGroups().size(); i++) {
             final Settings.DisplayGroup displayGroup = nameTag.displayGroups().get(i);
             replaceDisplayIfNeeded(player, i, displayGroup);
@@ -1185,30 +1427,29 @@ public class NameTagManager implements UntNametagManager {
 
             final List<Player> relationalPlayers = relationalPlayersForRefresh(player, display);
 
-            plugin.getPlaceholderManager().applyPlaceholders(player, displayGroup, relationalPlayers)
-                    .thenAccept(lines -> {
-                        final Component component = lines.get(player);
-                        if (component == null) {
-                            plugin.getLogger().warning(
-                                    "No nametag component for owner " + player.getName() + "; swap skipped for one row.");
-                            return;
-                        }
-                        loadDisplay(player, component, displayGroup, display);
-                        final NametagDisplayType dt = displayGroup.resolvedDisplayType();
-                        if (dt == NametagDisplayType.TEXT) {
-                            lines.forEach((p, c) -> {
-                                if (!p.equals(player) && c != null) {
-                                    display.text(p, c);
-                                }
-                            });
-                        }
-                    })
-                    .exceptionally(throwable -> {
-                        plugin.getLogger().log(java.util.logging.Level.SEVERE,
-                                "Failed to swap nametag for " + player.getName(), throwable);
-                        return null;
-                    });
+            futures.add(resolveDisplayRow(player, i, displayGroup, display, relationalPlayers, "swap"));
         }
+
+        CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).thenRun(() -> {
+            final List<ResolvedDisplayRow> rows = collectResolvedRows(futures);
+            for (ResolvedDisplayRow row : rows) {
+                final Component component = row.ownerComponent();
+                if (component == null) {
+                    plugin.getLogger().warning(
+                            "No nametag component for owner " + player.getName() + "; swap skipped for one row.");
+                    continue;
+                }
+                loadDisplay(player, component, row.displayGroup(), row.display());
+                if (row.displayGroup().resolvedDisplayType() == NametagDisplayType.TEXT) {
+                    row.components().forEach((p, c) -> {
+                        if (!p.equals(player) && c != null) {
+                            row.display().text(p, c);
+                        }
+                    });
+                }
+            }
+            applyDisplayGroupStackLayout(player, rows);
+        });
 
     }
 

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -70,6 +71,11 @@ public abstract class PacketNameTag implements UntNametagDisplay, NametagAnimati
     private boolean sneaking;
 
     private float baseTranslationY;
+    private boolean compactStackLayout;
+    private float compactStackYOffset;
+    private boolean compactStackHelmetOffset = true;
+    /** Per-viewer base translation Y (before animation offsets) when compact stacking is relational. */
+    private final ConcurrentHashMap<UUID, Float> perViewerStackBaseY = new ConcurrentHashMap<>();
     /**
      * Extra vertical offset (in blocks) added to compensate tall cosmetic helmets.
      * See {@link org.alexdev.unlimitednametags.hook.hat.HatHook} and issue #49: previously the plugin injected
@@ -279,8 +285,51 @@ public abstract class PacketNameTag implements UntNametagDisplay, NametagAnimati
         applyDisplayTransform();
     }
 
+    public void setCompactStackYOffset(float yOffset, boolean includeHelmetOffset) {
+        perViewerStackBaseY.clear();
+        this.compactStackLayout = true;
+        this.compactStackYOffset = yOffset;
+        this.compactStackHelmetOffset = includeHelmetOffset;
+        recomputeBaseTranslationY();
+        applyDisplayTransform();
+    }
+
+    public void clearCompactStackYOffset() {
+        final boolean hadPerViewer = !perViewerStackBaseY.isEmpty();
+        perViewerStackBaseY.clear();
+        if (!compactStackLayout && compactStackHelmetOffset && !hadPerViewer) {
+            return;
+        }
+        this.compactStackLayout = false;
+        this.compactStackYOffset = 0f;
+        this.compactStackHelmetOffset = true;
+        recomputeBaseTranslationY();
+        applyDisplayTransform();
+    }
+
+    public void setPerViewerStackBaseY(@NotNull Map<UUID, Float> baseYByViewer) {
+        this.compactStackLayout = false;
+        this.compactStackYOffset = 0f;
+        this.compactStackHelmetOffset = true;
+        perViewerStackBaseY.clear();
+        perViewerStackBaseY.putAll(baseYByViewer);
+        recomputeBaseTranslationY();
+        applyDisplayTransform();
+    }
+
+    public void clearPerViewerStackLayout() {
+        if (perViewerStackBaseY.isEmpty()) {
+            return;
+        }
+        perViewerStackBaseY.clear();
+        recomputeBaseTranslationY();
+        applyDisplayTransform();
+    }
+
     private void recomputeBaseTranslationY() {
-        this.baseTranslationY = offset + increasedOffset + displayGroup.yOffset() + helmetExtraOffset;
+        final float rowOffset = compactStackLayout ? compactStackYOffset : displayGroup.yOffset();
+        final float helmetOffset = !compactStackLayout || compactStackHelmetOffset ? helmetExtraOffset : 0f;
+        this.baseTranslationY = offset + increasedOffset + rowOffset + helmetOffset;
     }
 
     /**
@@ -303,17 +352,41 @@ public abstract class PacketNameTag implements UntNametagDisplay, NametagAnimati
         if (removed) {
             return;
         }
-        final float y = baseTranslationY + animationTy;
         final float tx = animationTx;
         final float tz = animationTz;
         final Quaternion4f lq = new Quaternion4f(
                 animationLeftQuat.getX(), animationLeftQuat.getY(), animationLeftQuat.getZ(), animationLeftQuat.getW());
         final float sc = scale * animationScaleMul;
-        modifyAbstractAll(meta -> {
-            meta.setTranslation(new Vector3f(tx, y, tz));
-            meta.setLeftRotation(lq);
-            meta.setScale(new Vector3f(sc, sc, sc));
-        });
+        if (!perViewerStackBaseY.isEmpty()) {
+            for (final UUID viewerId : new ArrayList<>(perPlayerEntity.getEntities().keySet())) {
+                Player p = plugin.getPlayerListener().getPlayer(viewerId);
+                if (p == null) {
+                    p = Bukkit.getPlayer(viewerId);
+                }
+                if (p == null) {
+                    continue;
+                }
+                final User user = PacketEvents.getAPI().getPlayerManager().getUser(p);
+                if (user == null) {
+                    continue;
+                }
+                final float baseY = perViewerStackBaseY.getOrDefault(viewerId, baseTranslationY);
+                final float y = baseY + animationTy;
+                modifyEntity(user, w -> {
+                    final AbstractDisplayMeta meta = (AbstractDisplayMeta) w.getEntityMeta();
+                    meta.setTranslation(new Vector3f(tx, y, tz));
+                    meta.setLeftRotation(lq);
+                    meta.setScale(new Vector3f(sc, sc, sc));
+                });
+            }
+        } else {
+            final float y = baseTranslationY + animationTy;
+            modifyAbstractAll(meta -> {
+                meta.setTranslation(new Vector3f(tx, y, tz));
+                meta.setLeftRotation(lq);
+                meta.setScale(new Vector3f(sc, sc, sc));
+            });
+        }
         // EntityLib keeps notifyAboutChanges(false) on display meta; translation/rotation updates otherwise stay server-side only.
         refresh();
     }

--- a/plugin/src/main/java/org/alexdev/unlimitednametags/placeholders/PlaceholderManager.java
+++ b/plugin/src/main/java/org/alexdev/unlimitednametags/placeholders/PlaceholderManager.java
@@ -10,6 +10,7 @@ import org.alexdev.unlimitednametags.config.Settings;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -159,6 +160,16 @@ public class PlaceholderManager {
     @NotNull
     public CompletableFuture<Map<Player, Component>> applyPlaceholders(@NotNull Player player, @NotNull Settings.DisplayGroup group,
                                                                        @NotNull List<Player> relationalPlayers) {
+        if (group.relationalConditions()) {
+            return CompletableFuture.supplyAsync(() -> {
+                final Map<Player, Component> result = Maps.newHashMapWithExpectedSize(relationalPlayers.size());
+                for (Player viewer : relationalPlayers) {
+                    final List<String> strings = collectActiveLineTexts(player, viewer, group);
+                    result.put(viewer, buildComponentForViewer(player, viewer, strings));
+                }
+                return result;
+            }, executorService);
+        }
         return getCheckedLines(player, group).thenApplyAsync(strings -> createComponent(player, strings, relationalPlayers), executorService);
     }
 
@@ -172,22 +183,76 @@ public class PlaceholderManager {
 
     /**
      * Same visibility as checked lines resolution: when {@code false}, text lines are empty and item/block displays should hide content.
+     * When {@code relationalViewer} is non-null and the group has {@link Settings.DisplayGroup#relationalConditions()},
+     * the group {@code when} is evaluated with relational placeholders (viewer → owner).
+     */
+    public boolean isDisplayGroupActive(@NotNull Player owner, @NotNull Settings.DisplayGroup group, @Nullable Player relationalViewer) {
+        if (group.when() == null || group.when().isBlank()) {
+            return true;
+        }
+        final String expr = group.when().trim();
+        if (!group.relationalConditions() || relationalViewer == null) {
+            return plugin.getConditionalManager().evaluateCondition(expr, owner);
+        }
+        return plugin.getConditionalManager().evaluateCondition(expr, relationalViewer, owner);
+    }
+
+    /**
+     * Same as {@link #isDisplayGroupActive(Player, Settings.DisplayGroup, Player)} with {@code relationalViewer = null} (owner-based).
      */
     public boolean isDisplayGroupActive(@NotNull Player player, @NotNull Settings.DisplayGroup group) {
-        if (group.when() != null && !group.when().isBlank()) {
-            return plugin.getConditionalManager().evaluateCondition(group.when().trim(), player);
+        return isDisplayGroupActive(player, group, null);
+    }
+
+    @NotNull
+    private List<String> collectActiveLineTexts(@NotNull Player owner, @NotNull Player viewer, @NotNull Settings.DisplayGroup group) {
+        if (!isDisplayGroupActive(owner, group, group.relationalConditions() ? viewer : null)) {
+            return List.of();
         }
-        return true;
+        return group.lines().stream()
+                .filter(line -> line.when() == null
+                        || line.when().isBlank()
+                        || evaluateLineWhen(owner, viewer, line, group.relationalConditions()))
+                .map(Settings.NametagLine::text)
+                .toList();
+    }
+
+    private boolean evaluateLineWhen(@NotNull Player owner, @NotNull Player viewer, @NotNull Settings.NametagLine line, boolean relationalGroup) {
+        if (line.when() == null || line.when().isBlank()) {
+            return true;
+        }
+        final String expr = line.when().trim();
+        if (!relationalGroup) {
+            return plugin.getConditionalManager().evaluateCondition(expr, owner);
+        }
+        return plugin.getConditionalManager().evaluateCondition(expr, viewer, owner);
+    }
+
+    @NotNull
+    private Component buildComponentForViewer(@NotNull Player owner, @NotNull Player viewer, @NotNull List<String> strings) {
+        final Settings settings = plugin.getConfigManager().getSettings();
+        final boolean removeEmptyLines = settings.isRemoveEmptyLines();
+
+        final List<String> baseStrings = papiManager.isPapiEnabled() ?
+                strings.stream()
+                        .map(s -> replacePlaceholders(s, owner, null))
+                        .toList()
+                : strings;
+
+        List<Component> processedLines = baseStrings.stream()
+                .map(line -> replacePlaceholders(line, owner, viewer))
+                .filter(s -> !removeEmptyLines || !s.isEmpty())
+                .map(this::formatPhases)
+                .map(line -> format(line, owner))
+                .filter(c -> !removeEmptyLines || !c.equals(Component.empty()))
+                .toList();
+
+        return joinLines(processedLines);
     }
 
     @NotNull
     private CompletableFuture<List<String>> getCheckedLines(@NotNull Player player, @NotNull Settings.DisplayGroup group) {
-        return CompletableFuture.supplyAsync(() -> {
-            if (!isDisplayGroupActive(player, group)) {
-                return List.of();
-            }
-            return group.lines();
-        }, executorService);
+        return CompletableFuture.supplyAsync(() -> collectActiveLineTexts(player, player, group), executorService);
     }
 
     @NotNull


### PR DESCRIPTION
Adds a health-based nametag refresh option. Adds `healthRefresh` in `Settings.java` and listens for `UPDATE_HEALTH` packets in `PacketEventsListener`. Stores each player's last rounded health and only updates the nametag when the visible health value changes.