### PR TITLE
Fix nametag passenger display order

### DIFF
--- a/paper/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
@@ -17,6 +17,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTe
 import com.google.common.collect.Maps;
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
 import org.alexdev.unlimitednametags.data.TeamData;
+import org.alexdev.unlimitednametags.packet.PacketNameTag;
 import org.alexdev.unlimitednametags.packet.PaperNametagRow;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -129,17 +130,23 @@ public class PacketEventsListener extends PacketListenerAbstract {
             return;
         }
 
-        for (PaperNametagRow row : packetNameTags) {
-            final int entityId = ((org.alexdev.unlimitednametags.packet.PacketNameTag) row).getEntityId();
-            if (!passengers.contains(entityId)) {
-                passengers.add(entityId);
-                passengers.sort(Comparator.naturalOrder());
-                packet.setPassengers(passengers.stream().mapToInt(i -> i).toArray());
-                event.markForReEncode(true);
-            }
+        final List<Integer> displayEntityIds = packetNameTags.stream()
+                .map(row -> ((PacketNameTag) row).displayEntityId())
+                .toList();
+        final Set<Integer> displayEntityIdSet = new HashSet<>(displayEntityIds);
+        final List<Integer> vanillaPassengers = passengers.stream()
+                .filter(passenger -> !displayEntityIdSet.contains(passenger))
+                .toList();
+        final List<Integer> updatedPassengers = new ArrayList<>(vanillaPassengers.size() + displayEntityIds.size());
+        updatedPassengers.addAll(vanillaPassengers);
+        updatedPassengers.addAll(displayEntityIds);
+
+        if (!updatedPassengers.equals(passengers)) {
+            packet.setPassengers(updatedPassengers.stream().mapToInt(Integer::intValue).toArray());
+            event.markForReEncode(true);
         }
 
-        plugin.getPacketManager().setPassengers(player.get(), passengers);
+        plugin.getPacketManager().setPassengers(player.get(), vanillaPassengers);
     }
 
     @NotNull

--- a/paper/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
@@ -151,7 +151,7 @@ public class PacketEventsListener extends PacketListenerAbstract {
 
     @NotNull
     private List<Integer> collectPassengers(int[] passengers) {
-        final  List<Integer> passengerList = new ArrayList<>(passengers.length);
+        final List<Integer> passengerList = new ArrayList<>(passengers.length);
         for (int passenger : passengers) {
             passengerList.add(passenger);
         }

--- a/paper/src/main/java/org/alexdev/unlimitednametags/packet/PacketManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/packet/PacketManager.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.UUID;
@@ -31,7 +32,7 @@ public class PacketManager {
     public PacketManager(@NotNull UnlimitedNameTags plugin) {
         this.plugin = plugin;
         this.initialize();
-        this.passengers = new ConcurrentMultimap<>();
+        this.passengers = new ConcurrentMultimap<>(() -> Collections.synchronizedSet(new LinkedHashSet<>()));
         final ThreadFactory namedThreadFactory = new ThreadFactoryBuilder()
                 .setNameFormat("UnlimitedNameTags-PacketManager-%d")
                 .build();
@@ -71,7 +72,9 @@ public class PacketManager {
             final Collection<Integer> ownerPassengers = this.passengers.get(owner.getUniqueId());
             final LinkedHashSet<Integer> passengers = new LinkedHashSet<>(
                     ownerPassengers.size() + entityIds.size());
-            ownerPassengers.stream().sorted().forEach(passengers::add);
+            ownerPassengers.stream()
+                    .filter(passenger -> !entityIds.contains(passenger))
+                    .forEach(passengers::add);
             passengers.addAll(entityIds);
             final int[] passengersArray = passengers.stream().mapToInt(Integer::intValue).toArray();
             final WrapperPlayServerSetPassengers packet = new WrapperPlayServerSetPassengers(owner.getEntityId(), passengersArray);

--- a/paper/src/main/java/org/alexdev/unlimitednametags/packet/PacketManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/packet/PacketManager.java
@@ -15,10 +15,12 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -32,7 +34,7 @@ public class PacketManager {
     public PacketManager(@NotNull UnlimitedNameTags plugin) {
         this.plugin = plugin;
         this.initialize();
-        this.passengers = new ConcurrentMultimap<>(() -> Collections.synchronizedSet(new LinkedHashSet<>()));
+        this.passengers = new ConcurrentMultimap<>(CopyOnWriteArraySet::new);
         final ThreadFactory namedThreadFactory = new ThreadFactoryBuilder()
                 .setNameFormat("UnlimitedNameTags-PacketManager-%d")
                 .build();
@@ -64,6 +66,7 @@ public class PacketManager {
         final List<Integer> entityIds = packetNameTags.stream()
                 .map(NametagPassengerSource::displayEntityId)
                 .toList();
+        final Set<Integer> entityIdSet = new HashSet<>(entityIds);
         executorService.submit(() -> {
             if (player.getChannel() == null) {
                 return;
@@ -73,7 +76,7 @@ public class PacketManager {
             final LinkedHashSet<Integer> passengers = new LinkedHashSet<>(
                     ownerPassengers.size() + entityIds.size());
             ownerPassengers.stream()
-                    .filter(passenger -> !entityIds.contains(passenger))
+                    .filter(passenger -> !entityIdSet.contains(passenger))
                     .forEach(passengers::add);
             passengers.addAll(entityIds);
             final int[] passengersArray = passengers.stream().mapToInt(Integer::intValue).toArray();


### PR DESCRIPTION
## Summary
- preserve vanilla passenger order instead of sorting by entity id
- remove duplicate UNT display ids before appending nametag displays
- append nametag display ids in displayGroups/getPacketDisplays order

## Test
- JAVA_HOME=/tmp/jdks/jdk-21 PATH=/tmp/jdks/jdk-21/bin:$PATH bash ./gradlew :paper:compileJava --no-daemon