### PR TITLE
Fix virtual cosmetic hat height sources

### DIFF
--- a/api-paper/src/main/java/org/alexdev/unlimitednametags/hook/hat/HatHookPaper.java
+++ b/api-paper/src/main/java/org/alexdev/unlimitednametags/hook/hat/HatHookPaper.java
@@ -1,11 +1,32 @@
 package org.alexdev.unlimitednametags.hook.hat;
 
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public interface HatHookPaper extends HatHook {
 
     default double getHigh(@NotNull Player player) {
         return getHigh(player.getUniqueId());
+    }
+
+    /**
+     * Returns additional Paper-side hat item sources exposed by this hook, for example virtual cosmetics that are not
+     * present in the vanilla helmet equipment slot. Implementations should not include empty/air items.
+     */
+    @NotNull
+    default List<ItemStack> getHatItems(@NotNull Player player) {
+        return List.of();
+    }
+
+    /**
+     * Computes the raw hat height for the supplied item source. This lets item/model based hooks evaluate both the
+     * real helmet item and virtual cosmetic items supplied by other hooks without requiring the item to be equipped.
+     */
+    default double getHigh(@NotNull Player player, @Nullable ItemStack item) {
+        return 0;
     }
 }

--- a/paper/src/main/java/org/alexdev/unlimitednametags/hook/AdvancedHatHook.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/hook/AdvancedHatHook.java
@@ -2,19 +2,20 @@ package org.alexdev.unlimitednametags.hook;
 
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
 import org.alexdev.unlimitednametags.config.Advanced;
-import org.alexdev.unlimitednametags.hook.hat.HatHook;
+import org.alexdev.unlimitednametags.hook.hat.HatHookPaper;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public final class AdvancedHatHook implements HatHook {
+public final class AdvancedHatHook implements HatHookPaper {
 
     private final UnlimitedNameTags plugin;
 
@@ -28,6 +29,13 @@ public final class AdvancedHatHook implements HatHook {
         if (player == null) {
             return 0;
         }
+
+        final ItemStack helmet = player.getInventory().getHelmet();
+        return getHigh(player, helmet);
+    }
+
+    @Override
+    public double getHigh(@NotNull Player player, @Nullable ItemStack helmet) {
         final Advanced advanced = plugin.getConfigManager().getAdvanced();
         final List<Advanced.HelmetHeightRule> rules = advanced.getHelmetHeightRules();
         final boolean verbose = HelmetDebugContext.isVerbose();
@@ -39,7 +47,6 @@ public final class AdvancedHatHook implements HatHook {
             return 0;
         }
 
-        final ItemStack helmet = player.getInventory().getHelmet();
         if (helmet == null || helmet.getType().isAir()) {
             if (verbose) {
                 plugin.getLogger().info("[UNT helmet dbg] AdvancedHatHook: helmet slot empty");

--- a/paper/src/main/java/org/alexdev/unlimitednametags/hook/HMCCosmeticsHook.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/hook/HMCCosmeticsHook.java
@@ -1,7 +1,6 @@
 package org.alexdev.unlimitednametags.hook;
 
 import com.hibiscusmc.hmccosmetics.api.HMCCosmeticsAPI;
-import com.hibiscusmc.hmccosmetics.cosmetic.Cosmetic;
 import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
@@ -63,12 +62,11 @@ public class HMCCosmeticsHook extends Hook implements HatHookPaper {
             return List.of();
         }
 
-        final Cosmetic cosmetic = user.getCosmetic(CosmeticSlot.HELMET);
-        if (cosmetic == null) {
+        if (!user.hasCosmeticInSlot(CosmeticSlot.HELMET)) {
             return List.of();
         }
 
-        final ItemStack item = cosmetic.getItem();
+        final ItemStack item = user.getUserCosmeticItem(CosmeticSlot.HELMET);
         if (item == null || item.getType().isAir()) {
             return List.of();
         }

--- a/paper/src/main/java/org/alexdev/unlimitednametags/hook/HMCCosmeticsHook.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/hook/HMCCosmeticsHook.java
@@ -6,14 +6,16 @@ import com.hibiscusmc.hmccosmetics.cosmetic.CosmeticSlot;
 import com.hibiscusmc.hmccosmetics.user.CosmeticUser;
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
 import org.alexdev.unlimitednametags.hook.creative.CreativeHook;
-import org.alexdev.unlimitednametags.hook.hat.HatHook;
+import org.alexdev.unlimitednametags.hook.hat.HatHookPaper;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.UUID;
 
-public class HMCCosmeticsHook extends Hook implements HatHook {
+public class HMCCosmeticsHook extends Hook implements HatHookPaper {
 
     private CreativeHook creativeHook;
 
@@ -48,21 +50,37 @@ public class HMCCosmeticsHook extends Hook implements HatHook {
         if (player == null) {
             return 0;
         }
-        final CosmeticUser user = HMCCosmeticsAPI.getUser(playerId);
+        return getHatItems(player).stream()
+                .mapToDouble(item -> getHigh(player, item))
+                .max()
+                .orElse(0);
+    }
+
+    @Override
+    public @NotNull List<ItemStack> getHatItems(@NotNull Player player) {
+        final CosmeticUser user = HMCCosmeticsAPI.getUser(player.getUniqueId());
         if (user == null) {
-            return 0;
+            return List.of();
         }
 
         final Cosmetic cosmetic = user.getCosmetic(CosmeticSlot.HELMET);
         if (cosmetic == null) {
-            return 0;
+            return List.of();
         }
 
         final ItemStack item = cosmetic.getItem();
-        if (item == null) {
-            return 0;
+        if (item == null || item.getType().isAir()) {
+            return List.of();
         }
 
+        return List.of(item);
+    }
+
+    @Override
+    public double getHigh(@NotNull Player player, @Nullable ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return 0;
+        }
         if (creativeHook != null) {
             return creativeHook.getHigh(item);
         }

--- a/paper/src/main/java/org/alexdev/unlimitednametags/hook/NexoHook.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/hook/NexoHook.java
@@ -10,12 +10,13 @@ import lombok.Getter;
 import net.kyori.adventure.key.Key;
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
 import org.alexdev.unlimitednametags.hook.creative.CreativeHook;
-import org.alexdev.unlimitednametags.hook.hat.HatHook;
+import org.alexdev.unlimitednametags.hook.hat.HatHookPaper;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 import team.unnamed.creative.ResourcePack;
@@ -25,7 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Getter
-public class NexoHook extends Hook implements Listener, CreativeHook, HatHook {
+public class NexoHook extends Hook implements Listener, CreativeHook, HatHookPaper {
 
     private final Map<Key, Map<Integer, Model>> cmdCache;
     private ResourcePack resourcePack;
@@ -46,12 +47,27 @@ public class NexoHook extends Hook implements Listener, CreativeHook, HatHook {
         if (player == null) {
             return 0;
         }
+        return getHigh(player);
+    }
+
+    @Override
+    public double getHigh(@NotNull Player player) {
         final double v = CreativeHook.super.getHigh(player);
         if (HelmetDebugContext.isVerbose()) {
-            final var helmet = player.getInventory().getHelmet();
-            final boolean empty = helmet == null || helmet.getType().isAir();
-            final Optional<Model> resolved = empty ? Optional.empty() : findModel(helmet);
-            plugin.getLogger().info("[UNT helmet dbg] NexoHook: super.getHigh=" + v
+            plugin.getLogger().info("[UNT helmet dbg] NexoHook: getHigh=" + v);
+        }
+        return v;
+    }
+
+    @Override
+    public double getHigh(@NotNull Player player, @Nullable ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return 0;
+        }
+        final double v = CreativeHook.super.getHigh(item);
+        if (HelmetDebugContext.isVerbose()) {
+            final Optional<Model> resolved = findModel(item);
+            plugin.getLogger().info("[UNT helmet dbg] NexoHook: source item getHigh=" + v
                     + " findModelResolved=" + resolved.isPresent());
         }
         return v;

--- a/paper/src/main/java/org/alexdev/unlimitednametags/placeholders/PlaceholderManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/placeholders/PlaceholderManager.java
@@ -15,7 +15,9 @@ import org.alexdev.unlimitednametags.hook.HelmetDebugContext;
 import org.alexdev.unlimitednametags.hook.HelmetRuleDebugThrottle;
 import org.alexdev.unlimitednametags.hook.HelmetRuleDiagnostics;
 import org.alexdev.unlimitednametags.hook.hat.HatHook;
+import org.alexdev.unlimitednametags.hook.hat.HatHookPaper;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,6 +25,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -362,6 +365,11 @@ public class PlaceholderManager {
                 plugin.getLogger().info("[UNT helmet dbg] computing offset (hat hooks=" + plugin.getHatHooks().size() + ")");
             }
 
+            final List<ItemStack> hatSources = collectHatSources(player);
+            if (verbose) {
+                plugin.getLogger().info("[UNT helmet dbg] hat item sources=" + hatSources.size());
+            }
+
             double rawHeight = 0d;
             HatHook winner = null;
             for (final HatHook hook : plugin.getHatHooks()) {
@@ -369,15 +377,28 @@ public class PlaceholderManager {
                 if (verbose) {
                     plugin.getLogger().info("[UNT helmet dbg]   " + hook.getClass().getSimpleName() + ".getHigh -> " + v);
                 }
-                if (v > 0d && rawHeight <= 0d) {
+                if (v > rawHeight) {
                     rawHeight = v;
                     winner = hook;
-                    break;
+                }
+
+                if (hook instanceof HatHookPaper paperHook) {
+                    for (final ItemStack source : hatSources) {
+                        final double sourceHeight = paperHook.getHigh(player, source);
+                        if (verbose) {
+                            plugin.getLogger().info("[UNT helmet dbg]   " + hook.getClass().getSimpleName()
+                                    + ".getHigh(source=" + source.getType() + ") -> " + sourceHeight);
+                        }
+                        if (sourceHeight > rawHeight) {
+                            rawHeight = sourceHeight;
+                            winner = hook;
+                        }
+                    }
                 }
             }
 
             if (verbose) {
-                plugin.getLogger().info("[UNT helmet dbg] first hook with height>0: "
+                plugin.getLogger().info("[UNT helmet dbg] max hook/source height>0: "
                         + (winner == null ? "<none>" : winner.getClass().getSimpleName())
                         + " rawHeight=" + rawHeight);
             }
@@ -397,6 +418,32 @@ public class PlaceholderManager {
         } finally {
             HelmetDebugContext.clear();
         }
+    }
+
+    private @NotNull List<ItemStack> collectHatSources(@NotNull Player player) {
+        final List<ItemStack> sources = new ArrayList<>();
+        final ItemStack helmet = player.getInventory().getHelmet();
+        addHatSource(sources, helmet);
+        for (final HatHook hook : plugin.getHatHooks()) {
+            if (hook instanceof HatHookPaper paperHook) {
+                for (final ItemStack item : paperHook.getHatItems(player)) {
+                    addHatSource(sources, item);
+                }
+            }
+        }
+        return sources;
+    }
+
+    private void addHatSource(@NotNull List<ItemStack> sources, @Nullable ItemStack item) {
+        if (item == null || item.getType().isAir()) {
+            return;
+        }
+        for (final ItemStack existing : sources) {
+            if (existing.isSimilar(item)) {
+                return;
+            }
+        }
+        sources.add(item);
     }
 
     private Component joinLines(List<Component> lines) {


### PR DESCRIPTION
## Summary
- let Paper hat hooks expose virtual hat item sources
- evaluate real and virtual hat sources across hooks
- use max positive height instead of first positive hook result
- support HMCCosmetics virtual helmet items for Advanced/Nexo height resolution

## Test
- JAVA_HOME=/tmp/jdks/jdk-21 PATH=/tmp/jdks/jdk-21/bin:$PATH bash ./gradlew :paper:compileJava --no-daemon