### PR TITLE
Centralize text display visual state

### DIFF
--- a/common/src/main/java/org/alexdev/unlimitednametags/packet/TextNametagSupport.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/packet/TextNametagSupport.java
@@ -138,8 +138,7 @@ final class TextNametagSupport {
         }
 
         final UUID ownerId = host.getOwnerId();
-        final boolean groupSeeThrough = host.getDisplayGroup().effectiveBackground().seeThrough();
-        final boolean baseSeeThrough = groupSeeThrough && !sneakEffective;
+        final boolean baseSeeThrough = false;
 
         for (final UUID viewerId : new ArrayList<>(host.getViewers())) {
             if (host.getPlatform().viewerLacksTextDisplaySupport(viewerId)) {

--- a/paper/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
@@ -185,7 +185,11 @@ public class NameTagManager implements UntNametagManagerPaper {
                             continue;
                         }
 
-                        final boolean isPointing = isPlayerPointingAt(viewer, targetOwner);
+                        boolean isPointing = isPlayerPointingAt(viewer, targetOwner);
+                        if (isPointing && plugin.getConfigManager().getSettings().getVisibility().getThroughWallMode()
+                                == Settings.ThroughWallMode.HIDE && !viewer.hasLineOfSight(targetOwner)) {
+                            isPointing = false;
+                        }
 
                         if (paperRow(tag).canPlayerSee(viewer) && !isPointing) {
                             paperRow(tag).hideFromPlayer(viewer);
@@ -1358,11 +1362,20 @@ public class NameTagManager implements UntNametagManagerPaper {
     }
 
     public void reload() {
-        final float yOffset = plugin.getConfigManager().getSettings().getBehavior().getYOffset();
-        final float viewDistance = plugin.getConfigManager().getSettings().getBehavior().getViewDistance();
-        if (plugin.getConfigManager().getSettings().getVisibility().getThroughWallMode() == Settings.ThroughWallMode.SEE_THROUGH) {
-            nameTags.values().forEach(tags -> tags.forEach(PacketNameTag::clearObscuredPresentationTracking));
-        }
+        final Settings settings = plugin.getConfigManager().getSettings();
+        final float yOffset = settings.getBehavior().getYOffset();
+        final float viewDistance = settings.getBehavior().getViewDistance();
+        final Settings.ThroughWallMode throughWallMode = settings.getVisibility().getThroughWallMode();
+        final byte sneakOpacity = clampMcTextOpacity(settings.getVisibility().getSneakOpacity());
+        nameTags.values().forEach(tags -> tags.forEach(tag -> {
+            tag.clearObscuredPresentationTracking();
+            if (tag.isTextDisplay()) {
+                applyTextVisualState(tag, tag.getDisplayGroup(), true);
+                if (throughWallMode != Settings.ThroughWallMode.OBSCURED) {
+                    tag.setTextOpacity(tag.isSneaking() ? sneakOpacity : (byte) -1);
+                }
+            }
+        }));
         plugin.getTaskScheduler()
                 .runTaskAsynchronously(() -> plugin.getPlayerListener().getOnlinePlayers().values().forEach(p -> {
                     setYOffset(p, yOffset);

--- a/paper/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
@@ -882,10 +882,12 @@ public class NameTagManager implements UntNametagManagerPaper {
     private void applyTextVisualState(@NotNull PacketNameTag display, @NotNull Settings.DisplayGroup displayGroup,
             @NotNull TextDisplayMeta meta, boolean force) {
         final boolean shadowed = displayGroup.effectiveBackground().shadowed();
-        final boolean seeThrough = displayGroup.effectiveBackground().seeThrough() && !display.isSneaking();
+        final Settings.ThroughWallMode throughWallMode = plugin.getConfigManager().getSettings()
+                .getVisibility().getThroughWallMode();
+        final boolean seeThrough = throughWallMode == Settings.ThroughWallMode.SEE_THROUGH
+                && displayGroup.effectiveBackground().seeThrough()
+                && !display.isSneaking();
         final int backgroundColor = displayGroup.effectiveBackground().getArgb();
-        final boolean obscuredMode = plugin.getConfigManager().getSettings().getVisibility().getThroughWallMode()
-                == Settings.ThroughWallMode.OBSCURED;
 
         if (force || meta.isShadow() != shadowed) {
             meta.setShadow(shadowed);
@@ -893,7 +895,7 @@ public class NameTagManager implements UntNametagManagerPaper {
         if (force || meta.getBackgroundColor() != backgroundColor) {
             meta.setBackgroundColor(backgroundColor);
         }
-        if (!obscuredMode && (force || meta.isSeeThrough() != seeThrough)) {
+        if (force || meta.isSeeThrough() != seeThrough) {
             meta.setSeeThrough(seeThrough);
         }
     }

--- a/paper/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import lombok.Getter;
 import lombok.Setter;
+import me.tofaa.entitylib.meta.display.TextDisplayMeta;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.TextColor;
@@ -860,10 +861,6 @@ public class NameTagManager implements UntNametagManagerPaper {
         }
 
         final PaperNametagRow row = paperRow(packetNameTag);
-        final boolean shadowed = displayGroup.effectiveBackground().shadowed();
-        final boolean seeThrough = displayGroup.effectiveBackground().seeThrough() && !packetNameTag.isSneaking();
-        final int backgroundColor = displayGroup.effectiveBackground().getArgb();
-        final boolean wallOpacity = cfg.getVisibility().getThroughWallMode() == Settings.ThroughWallMode.OBSCURED;
 
         components.forEach((p, c) -> {
             if (c == null) {
@@ -874,26 +871,31 @@ public class NameTagManager implements UntNametagManagerPaper {
             if (user == null) {
                 return;
             }
-            packetNameTag.modifyTextForViewer(user, m -> {
-                if (force) {
-                    m.setShadow(shadowed);
-                    if (!wallOpacity) {
-                        m.setSeeThrough(seeThrough);
-                    }
-                    m.setBackgroundColor(backgroundColor);
-                } else {
-                    if (m.isShadow() != shadowed) {
-                        m.setShadow(shadowed);
-                    }
-                    if (m.getBackgroundColor() != backgroundColor) {
-                        m.setBackgroundColor(backgroundColor);
-                    }
-                    if (!wallOpacity && m.isSeeThrough() != seeThrough) {
-                        m.setSeeThrough(seeThrough);
-                    }
-                }
-            });
+            packetNameTag.modifyTextForViewer(user, m -> applyTextVisualState(packetNameTag, displayGroup, m, force));
         });
+    }
+
+    private void applyTextVisualState(@NotNull PacketNameTag display, @NotNull Settings.DisplayGroup displayGroup, boolean force) {
+        display.modifyTextAll(meta -> applyTextVisualState(display, displayGroup, meta, force));
+    }
+
+    private void applyTextVisualState(@NotNull PacketNameTag display, @NotNull Settings.DisplayGroup displayGroup,
+            @NotNull TextDisplayMeta meta, boolean force) {
+        final boolean shadowed = displayGroup.effectiveBackground().shadowed();
+        final boolean seeThrough = displayGroup.effectiveBackground().seeThrough() && !display.isSneaking();
+        final int backgroundColor = displayGroup.effectiveBackground().getArgb();
+        final boolean obscuredMode = plugin.getConfigManager().getSettings().getVisibility().getThroughWallMode()
+                == Settings.ThroughWallMode.OBSCURED;
+
+        if (force || meta.isShadow() != shadowed) {
+            meta.setShadow(shadowed);
+        }
+        if (force || meta.getBackgroundColor() != backgroundColor) {
+            meta.setBackgroundColor(backgroundColor);
+        }
+        if (!obscuredMode && (force || meta.isSeeThrough() != seeThrough)) {
+            meta.setSeeThrough(seeThrough);
+        }
     }
 
     private void finishRowCreation(@NotNull UUID uuid) {
@@ -919,11 +921,7 @@ public class NameTagManager implements UntNametagManagerPaper {
             }
             display.setBillboard(displayGroup.effectiveBillboard(plugin.getConfigManager().getSettings()));
             if (dt == NametagDisplayType.TEXT) {
-                display.setShadowed(displayGroup.effectiveBackground().shadowed());
-                if (plugin.getConfigManager().getSettings().getVisibility().getThroughWallMode() != Settings.ThroughWallMode.OBSCURED) {
-                    display.setSeeThrough(displayGroup.effectiveBackground().seeThrough() && !display.isSneaking());
-                }
-                display.setBackgroundColor(displayGroup.effectiveBackground().getArgb());
+                applyTextVisualState(display, displayGroup, true);
             }
 
             display.resetOffset(plugin.getConfigManager().getSettings().getBehavior().getYOffset());
@@ -1349,9 +1347,7 @@ public class NameTagManager implements UntNametagManagerPaper {
                 if (isObscured) {
                     packetNameTag.applyObscuredLineOfSightPresentation(true, sneakB, obscB, maxSq, sneaking);
                 } else {
-                    if (packetNameTag.getDisplayGroup().effectiveBackground().seeThrough()) {
-                        packetNameTag.setSeeThrough(!sneaking);
-                    }
+                    applyTextVisualState(packetNameTag, packetNameTag.getDisplayGroup(), false);
                     packetNameTag.setTextOpacity(sneaking ? sneakB : (byte) -1);
                 }
             }


### PR DESCRIPTION
## Summary
- centralize text shadow/background/see-through metadata application
- reuse the same visual state path for load, edits, and sneak changes
- keep obscured through-wall mode in its dedicated line-of-sight path

## Test
- JAVA_HOME=/tmp/jdks/jdk-21 PATH=/tmp/jdks/jdk-21/bin:$PATH bash ./gradlew :paper:compileJava --no-daemon