### PR TITLE
fix: exclude EntityLib from Typewriter

### DIFF
--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     compileOnly(libs.typeWriter) {
         exclude(group = "io.papermc.paper")
         exclude(group = "com.github.Tofaa2.EntityLib")
-        exclude(group = "me.tofaa.entitylib")
+        exclude(group = "me.tofaa2")
     }
     compileOnly(libs.placeholderapi)
     compileOnly(libs.miniplaceholdersApi)


### PR DESCRIPTION
Yet another fix related to EntityLib dependency. 
Typewriter now uses `me.tofaa2` instead of `me.tofaa.entitylib`. If we run `./gradlew build --refresh-dependencies`, we'll get this error:
```
Execution failed for task ':paper:compileJava'.
> Could not resolve all files for configuration ':paper:compileClasspath'.
   > Could not resolve me.tofaa2:spigot:3.2.0-SNAPSHOT.
     Required by:
         project :paper > com.typewritermc:engine-paper:0.9.0
      > Could not resolve me.tofaa2:spigot:3.2.0-SNAPSHOT.
         > Could not get resource 'https://repo.feathermc.net/artifactory/maven-releases/me/tofaa2/spigot/3.2.0-SNAPSHOT/spigot-3.2.0-SNAPSHOT.pom'.
            > Could not GET 'https://repo.feathermc.net/artifactory/maven-releases/me/tofaa2/spigot/3.2.0-SNAPSHOT/spigot-3.2.0-SNAPSHOT.pom'. Received status code 409 from server: Conflict
      > Could not resolve me.tofaa2:spigot:3.2.0-SNAPSHOT.
         > Unable to load Maven meta-data from https://dist.labymod.net/api/v1/maven/release/me/tofaa2/spigot/3.2.0-SNAPSHOT/maven-metadata.xml.
            > Could not GET 'https://dist.labymod.net/api/v1/maven/release/me/tofaa2/spigot/3.2.0-SNAPSHOT/maven-metadata.xml'. Received status code 401 from server: Unauthorized
```
This PR fixes it.