### PR TITLE
Fix ItemsAdder packs with invalid texture metadata

### DIFF
--- a/paper/src/main/java/org/alexdev/unlimitednametags/hook/creative/CustomMinecraftResourcePackReaderImpl.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/hook/creative/CustomMinecraftResourcePackReaderImpl.java
@@ -227,7 +227,16 @@ public final class CustomMinecraftResourcePackReaderImpl implements MinecraftRes
                 if (keyOfMetadata != null) {
                     // found metadata for texture
                     Key key = Key.key(namespace, keyOfMetadata);
-                    Metadata metadata = MetadataSerializer.INSTANCE.readFromTree(parseJson(reader.stream()));
+                    Metadata metadata;
+                    try {
+                        metadata = MetadataSerializer.INSTANCE.readFromTree(parseJson(reader.stream()));
+                    } catch (RuntimeException e) {
+                        // ItemsAdder generated packs may contain non-object .mcmeta sidecar files
+                        // (for example a plain hash string). Texture metadata is optional for the
+                        // model-height lookup, so skip only this sidecar instead of aborting the
+                        // whole resource-pack load.
+                        continue;
+                    }
 
                     Map<Key, Texture> incompleteTexturesThisContainer = incompleteTextures.computeIfAbsent(overlayDir, k -> new LinkedHashMap<>());
                     Texture texture = incompleteTexturesThisContainer.remove(key);


### PR DESCRIPTION
## Summary
- skip malformed/non-object texture `.mcmeta` sidecars in ItemsAdder generated packs
- keep loading the rest of the resource pack so one bad file does not disable the whole pack

## Verification
- `JAVA_HOME=/home/hermes/.jdks/jdk-21 PATH=/home/hermes/.jdks/jdk-21/bin:$PATH bash ./gradlew :common:compileJava :api:compileJava :api-paper:compileJava --no-daemon`
- manual `javac` compile of `CustomMinecraftResourcePackReaderImpl` against Creative 1.7.3 jars
- synthetic zip smoke: texture `.png.mcmeta` containing `"0b928a97c6e801071c2a284a7a5a4df8"` loads without aborting

## Note
- Full `:paper:compileJava` is blocked by external dependency resolution for `me.tofaa2:spigot:3.2.0-SNAPSHOT` (Feather repo 409 / Labymod repo 401), same existing dependency gate.