### PR TITLE
fix: use in-memory signing for CI publishes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -39,11 +39,6 @@ jobs:
           distribution: temurin
           java-version: "21"
 
-      - name: Import GPG key
-        run: echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-
       - name: Publish release artifacts
         run: >
           bash ./gradlew :common:publish :api:publish :api-paper:publish
@@ -52,8 +47,8 @@ jobs:
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signing_gnupg_keyName: ${{ secrets.GPG_KEY_ID }}
-          ORG_GRADLE_PROJECT_signing_gnupg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Release reminder
         run: |

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -29,11 +29,6 @@ jobs:
           distribution: temurin
           java-version: "21"
 
-      - name: Import GPG key
-        run: echo "$GPG_PRIVATE_KEY" | gpg --batch --import
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-
       - name: Publish SNAPSHOT artifacts
         run: >
           bash ./gradlew :common:publish :api:publish :api-paper:publish
@@ -42,5 +37,5 @@ jobs:
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signing_gnupg_keyName: ${{ secrets.GPG_KEY_ID }}
-          ORG_GRADLE_PROJECT_signing_gnupg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,7 +155,13 @@ configure(publishableLibraryModules.keys.map { project(it) }) {
     }
 
     extensions.configure<SigningExtension> {
-        useGpgCmd()
+        val signingKey = findProperty("signingKey") as String? ?: System.getenv("GPG_PRIVATE_KEY")
+        val signingPassword = findProperty("signingPassword") as String? ?: System.getenv("GPG_PASSPHRASE")
+        if (!signingKey.isNullOrBlank()) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
+        } else {
+            useGpgCmd()
+        }
         sign(extensions.getByType<PublishingExtension>().publications.getByName("maven"))
     }
 }


### PR DESCRIPTION
## Summary
- stop importing the GPG key into the runner keyring
- pass `GPG_PRIVATE_KEY`/`GPG_PASSPHRASE` to Gradle as in-memory signing properties
- keep local fallback to `useGpgCmd()` when no in-memory key is provided

## Root cause
The previous fix got past `gradlew`, but the publish now fails at `:common:signMavenPublication` with:

```
gpg: signing failed: Inappropriate ioctl for device
Process command gpg finished with non-zero exit value 2
```

This happens because CI is non-interactive and `useGpgCmd()` invokes external `gpg`, which tries to use pinentry/TTY for the passphrase.

## Verification
- `actionlint .github/workflows/publish-snapshot.yml .github/workflows/publish-release.yml`
- `JAVA_HOME=/home/hermes/.cache/jdk21 PATH=/home/hermes/.cache/jdk21/bin:$PATH bash ./gradlew :common:compileJava :api:compileJava :api-paper:compileJava --no-daemon`
- generated a temporary passphrase-protected test PGP key and ran:
  `ORG_GRADLE_PROJECT_signingKey=... ORG_GRADLE_PROJECT_signingPassword=testpass bash ./gradlew :common:publishToMavenLocal :api:publishToMavenLocal :api-paper:publishToMavenLocal -Pversion=2.0.1-SNAPSHOT --no-daemon`