### PR TITLE
feat: add distance-based refresh culling

### DIFF
--- a/api-paper/src/main/java/org/alexdev/unlimitednametags/api/UntNametagManagerPaper.java
+++ b/api-paper/src/main/java/org/alexdev/unlimitednametags/api/UntNametagManagerPaper.java
@@ -178,6 +178,14 @@ public interface UntNametagManagerPaper extends UntNametagManager {
         return isShiftSystemBlocked(player.getUniqueId());
     }
 
+    default boolean isDistanceRefreshCullingBypassed(@NotNull Player player) {
+        return isDistanceRefreshCullingBypassed(player.getUniqueId());
+    }
+
+    default void setDistanceRefreshCullingBypassed(@NotNull Player player, boolean bypassed) {
+        setDistanceRefreshCullingBypassed(player.getUniqueId(), bypassed);
+    }
+
     default float getScale(@NotNull Player player) {
         return getScale(player.getUniqueId());
     }

--- a/api/src/main/java/org/alexdev/unlimitednametags/api/UntNametagManager.java
+++ b/api/src/main/java/org/alexdev/unlimitednametags/api/UntNametagManager.java
@@ -124,6 +124,14 @@ public interface UntNametagManager {
 
     boolean isShiftSystemBlocked(@NotNull UUID playerId);
 
+    boolean isDistanceRefreshCullingEnabled();
+
+    void setDistanceRefreshCullingEnabled(boolean enabled);
+
+    boolean isDistanceRefreshCullingBypassed(@NotNull UUID playerId);
+
+    void setDistanceRefreshCullingBypassed(@NotNull UUID playerId, boolean bypassed);
+
     boolean isDebug();
 
     void setDebug(boolean debug);

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -25,4 +25,10 @@ dependencies {
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
     compileOnly("org.jetbrains:annotations:26.0.2")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/common/src/main/java/org/alexdev/unlimitednametags/config/DistanceRefreshCulling.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/config/DistanceRefreshCulling.java
@@ -1,0 +1,60 @@
+package org.alexdev.unlimitednametags.config;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Computes a distance-aware refresh cadence for nametag placeholder updates.
+ * <p>
+ * Formula:
+ * <pre>
+ * n = clamp((distance - nearDistance) / (maxDistance - nearDistance), 0, 1)
+ * interval = baseInterval + (maxInterval - baseInterval) * n^curve
+ * </pre>
+ * Near players stay at the base refresh interval; farther players still refresh, but asymptotically slow down to
+ * {@code maxInterval}.
+ */
+public final class DistanceRefreshCulling {
+
+    private DistanceRefreshCulling() {
+    }
+
+    public static int intervalTicks(final int baseInterval, @NotNull Settings.DistanceRefreshCulling config,
+            final double nearestViewerDistance) {
+        if (!config.isEnabled()) {
+            return Math.max(1, baseInterval);
+        }
+        return intervalTicks(baseInterval, config.getMaxInterval(), config.getNearDistance(), config.getMaxDistance(),
+                config.getCurve(), nearestViewerDistance);
+    }
+
+    public static int intervalTicks(final int baseInterval, final int maxInterval, final double nearDistance,
+            final double maxDistance, final double curve, final double nearestViewerDistance) {
+        final int safeBase = Math.max(1, baseInterval);
+        final int safeMax = Math.max(safeBase, maxInterval);
+        if (Double.isNaN(nearestViewerDistance) || nearestViewerDistance <= nearDistance) {
+            return safeBase;
+        }
+        if (maxDistance <= nearDistance) {
+            return safeMax;
+        }
+
+        final double normalized = clamp01((nearestViewerDistance - nearDistance) / (maxDistance - nearDistance));
+        final double exponent = curve > 0.0 && Double.isFinite(curve) ? curve : 1.0;
+        final double factor = Math.pow(normalized, exponent);
+        return (int) Math.ceil(safeBase + (safeMax - safeBase) * factor);
+    }
+
+    public static boolean shouldRefresh(final long elapsedTicks, final int effectiveInterval) {
+        return elapsedTicks >= Math.max(1, effectiveInterval);
+    }
+
+    private static double clamp01(final double value) {
+        if (value <= 0.0) {
+            return 0.0;
+        }
+        if (value >= 1.0) {
+            return 1.0;
+        }
+        return value;
+    }
+}

--- a/common/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
@@ -24,7 +24,8 @@ public class Settings {
             "Schema version for settings.yml (managed by the plugin; do not lower).",
             "1 = flat NameTag, 2 = displayGroups with string lines, 3 = displayGroups with structured lines,",
             "4 = unified Background (no type: discriminator) + sectioned settings,",
-            "5 = throughWallMode, 6 = glowAnimations + per-row glow (current)."
+            "5 = throughWallMode, 6 = glowAnimations + per-row glow,",
+            "7 = distance refresh culling (current)."
     })
     private int configVersion = SettingsConfigVersion.CURRENT;
 
@@ -253,6 +254,34 @@ public class Settings {
                 "Example:  \"%vault_eco_balance%\": 100   (re-fetches balance at most every 100 ticks)"
         })
         private Map<String, Integer> placeholderUpdateRates = new LinkedHashMap<>();
+
+        @Comment({
+                "Distance-aware refresh culling for the periodic nametag placeholder refresh task.",
+                "Nearest viewers keep behavior.taskInterval; farther owners still refresh, but less often."
+        })
+        private DistanceRefreshCulling distanceRefreshCulling = new DistanceRefreshCulling();
+    }
+
+    @Configuration
+    @Getter
+    @Setter
+    @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
+    public static class DistanceRefreshCulling {
+
+        @Comment("Enable distance-aware refresh intervals for far-away nametags.")
+        private boolean enabled = true;
+
+        @Comment("Distance in blocks up to which nametags use behavior.taskInterval.")
+        private double nearDistance = 24.0;
+
+        @Comment("Distance in blocks at/after which nametags use maxInterval.")
+        private double maxDistance = 96.0;
+
+        @Comment("Slowest refresh interval in ticks for far-away/no-viewer nametags.")
+        private int maxInterval = 100;
+
+        @Comment("Curve exponent for interval growth. 1 = linear, 2 = gentle near / stronger far.")
+        private double curve = 2.0;
     }
 
     // ─── Nested types ─────────────────────────────────────────────────────────

--- a/common/src/main/java/org/alexdev/unlimitednametags/config/SettingsConfigVersion.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/config/SettingsConfigVersion.java
@@ -9,9 +9,9 @@ public final class SettingsConfigVersion {
     }
 
     /**
-     * Latest schema: version 6 introduces glowAnimations and per-display-group glow overrides.
+     * Latest schema: version 7 introduces distance refresh culling settings.
      */
-    public static final int CURRENT = 6;
+    public static final int CURRENT = 7;
 
     /**
      * {@code displayGroups} with {@link Settings.DisplayGroup}, structured {@code lines} as {@code {text, when?}} objects.

--- a/common/src/main/java/org/alexdev/unlimitednametags/config/SettingsYamlMigrator.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/config/SettingsYamlMigrator.java
@@ -83,6 +83,7 @@ public final class SettingsYamlMigrator {
                 case 3 -> changed |= migrateV3ToV4(root, log);
                 case 4 -> changed |= migrateV4ToV5(root, log);
                 case 5 -> changed |= migrateV5ToV6(root, log);
+                case 6 -> changed |= migrateV6ToV7(root, log);
                 default -> throw new IllegalStateException("Missing settings migrator from v" + v + " to v" + (v + 1));
             }
         }
@@ -740,6 +741,24 @@ public final class SettingsYamlMigrator {
         }
         root.put("glowAnimations", defaultGlowAnimationsYaml());
         log.info("Added default glowAnimations presets (v6).");
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean migrateV6ToV7(Map<String, Object> root, Logger log) {
+        final Map<String, Object> performance = (Map<String, Object>) root.computeIfAbsent("performance",
+                ignored -> new LinkedHashMap<>());
+        if (performance.containsKey("distanceRefreshCulling")) {
+            return false;
+        }
+        final Map<String, Object> culling = new LinkedHashMap<>();
+        culling.put("enabled", true);
+        culling.put("nearDistance", 24.0);
+        culling.put("maxDistance", 96.0);
+        culling.put("maxInterval", 100);
+        culling.put("curve", 2.0);
+        performance.put("distanceRefreshCulling", culling);
+        log.info("Added distance refresh culling settings (v7).");
         return true;
     }
 

--- a/common/src/test/java/org/alexdev/unlimitednametags/config/DistanceRefreshCullingTest.java
+++ b/common/src/test/java/org/alexdev/unlimitednametags/config/DistanceRefreshCullingTest.java
@@ -1,0 +1,42 @@
+package org.alexdev.unlimitednametags.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DistanceRefreshCullingTest {
+
+    @Test
+    void intervalStaysBaseInsideNearDistance() {
+        assertEquals(20, DistanceRefreshCulling.intervalTicks(20, 100, 24.0, 96.0, 2.0, 12.0));
+        assertEquals(20, DistanceRefreshCulling.intervalTicks(20, 100, 24.0, 96.0, 2.0, 24.0));
+    }
+
+    @Test
+    void intervalGrowsQuadraticallyUntilMaxDistance() {
+        assertEquals(40, DistanceRefreshCulling.intervalTicks(20, 100, 24.0, 96.0, 2.0, 60.0));
+        assertEquals(100, DistanceRefreshCulling.intervalTicks(20, 100, 24.0, 96.0, 2.0, 96.0));
+        assertEquals(100, DistanceRefreshCulling.intervalTicks(20, 100, 24.0, 96.0, 2.0, 200.0));
+    }
+
+    @Test
+    void disabledCullingAlwaysUsesBaseInterval() {
+        Settings.DistanceRefreshCulling cfg = new Settings.DistanceRefreshCulling();
+        cfg.setEnabled(false);
+        cfg.setNearDistance(24.0);
+        cfg.setMaxDistance(96.0);
+        cfg.setMaxInterval(100);
+        cfg.setCurve(2.0);
+
+        assertEquals(20, DistanceRefreshCulling.intervalTicks(20, cfg, 200.0));
+    }
+
+    @Test
+    void refreshWhenElapsedCatchesEffectiveInterval() {
+        assertFalse(DistanceRefreshCulling.shouldRefresh(39, 40));
+        assertTrue(DistanceRefreshCulling.shouldRefresh(40, 40));
+        assertTrue(DistanceRefreshCulling.shouldRefresh(80, 40));
+    }
+}

--- a/paper/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/nametags/NameTagManager.java
@@ -18,6 +18,7 @@ import org.alexdev.unlimitednametags.api.UntNametagDisplay;
 import org.alexdev.unlimitednametags.api.UntNametagDisplayCore;
 import org.alexdev.unlimitednametags.api.UntNametagManagerPaper;
 import org.alexdev.unlimitednametags.config.DisplayAnimation;
+import org.alexdev.unlimitednametags.config.DistanceRefreshCulling;
 import org.alexdev.unlimitednametags.config.GlowOverride;
 import org.alexdev.unlimitednametags.config.NametagDisplayType;
 import org.alexdev.unlimitednametags.config.Settings;
@@ -73,11 +74,14 @@ public class NameTagManager implements UntNametagManagerPaper {
     private final Map<UUID, Map<Integer, GlowOverride>> persistentGlowOverrides;
     private final Map<UUID, Map<Integer, DisplayAnimation>> sessionDisplayAnimations;
     private final Map<UUID, Map<Integer, DisplayAnimation>> persistentDisplayAnimations;
+    private final Map<UUID, Long> lastDistanceRefreshTicks;
+    private final Set<UUID> distanceRefreshCullingBypassed;
     private final Map<UUID, Boolean> shiftSystemBlocked;
     private final List<MyScheduledTask> tasks;
     private final AtomicLong displayAnimationMonotonicTick = new AtomicLong();
     @Setter
     private boolean debug = false;
+    private volatile boolean distanceRefreshCullingEnabled = true;
     private final Attribute scaleAttribute;
 
     private record ResolvedDisplayRow(
@@ -108,6 +112,8 @@ public class NameTagManager implements UntNametagManagerPaper {
         this.persistentGlowOverrides = Maps.newConcurrentMap();
         this.sessionDisplayAnimations = Maps.newConcurrentMap();
         this.persistentDisplayAnimations = Maps.newConcurrentMap();
+        this.lastDistanceRefreshTicks = Maps.newConcurrentMap();
+        this.distanceRefreshCullingBypassed = Sets.newConcurrentHashSet();
         this.shiftSystemBlocked = Maps.newConcurrentMap();
         this.loadAll();
         this.scaleAttribute = loadScaleAttribute();
@@ -139,14 +145,23 @@ public class NameTagManager implements UntNametagManagerPaper {
                 1L);
         tasks.add(displayAnimations);
 
+        final AtomicLong refreshSweepTick = new AtomicLong();
+        final int baseRefreshInterval = Math.max(1, plugin.getConfigManager().getSettings().getBehavior().getTaskInterval());
         final MyScheduledTask refresh = plugin.getTaskScheduler().runTaskTimerAsynchronously(
                 () -> {
                     if (plugin.isPaper() && plugin.getServer().isStopping()) {
                         return;
                     }
-                    nameTags.values().forEach(tags -> tags.forEach(tag -> refresh(paperRow(tag).getOwner(), false)));
+                    final long nowTick = refreshSweepTick.addAndGet(baseRefreshInterval);
+                    nameTags.values().stream()
+                            .flatMap(Collection::stream)
+                            .map(tag -> paperRow(tag).getOwner())
+                            .filter(Objects::nonNull)
+                            .distinct()
+                            .filter(owner -> shouldRefreshOwnerThisSweep(owner, nowTick, baseRefreshInterval))
+                            .forEach(owner -> refresh(owner, false));
                 },
-                10, plugin.getConfigManager().getSettings().getBehavior().getTaskInterval());
+                10, baseRefreshInterval);
         tasks.add(refresh);
 
         // Refresh passengers
@@ -211,6 +226,49 @@ public class NameTagManager implements UntNametagManagerPaper {
                     obscuredInterval);
             tasks.add(obscured);
         }
+    }
+
+    private boolean shouldRefreshOwnerThisSweep(@NotNull Player owner, final long nowTick, final int baseRefreshInterval) {
+        final UUID ownerId = owner.getUniqueId();
+        final Settings.DistanceRefreshCulling config = plugin.getConfigManager().getSettings()
+                .getPerformance().getDistanceRefreshCulling();
+        if (!distanceRefreshCullingEnabled || distanceRefreshCullingBypassed.contains(ownerId) || !config.isEnabled()) {
+            lastDistanceRefreshTicks.put(ownerId, nowTick);
+            return true;
+        }
+        final double nearestDistance = nearestViewerDistance(owner);
+        final int effectiveInterval = DistanceRefreshCulling.intervalTicks(baseRefreshInterval, config, nearestDistance);
+        final long lastTick = lastDistanceRefreshTicks.getOrDefault(ownerId, Long.MIN_VALUE);
+        if (lastTick == Long.MIN_VALUE || DistanceRefreshCulling.shouldRefresh(nowTick - lastTick, effectiveInterval)) {
+            lastDistanceRefreshTicks.put(ownerId, nowTick);
+            return true;
+        }
+        return false;
+    }
+
+    private double nearestViewerDistance(@NotNull Player owner) {
+        if (isEffectiveShowOwnNametag(owner)) {
+            return 0.0;
+        }
+
+        double nearestSq = Double.POSITIVE_INFINITY;
+        final Location ownerLocation = owner.getLocation();
+        for (Player viewer : plugin.getTrackerManager().getWhoTracks(owner)) {
+            if (viewer == null || !viewer.isOnline()) {
+                continue;
+            }
+            if (!viewer.getWorld().equals(owner.getWorld())) {
+                continue;
+            }
+            final double distanceSq = viewer.getLocation().distanceSquared(ownerLocation);
+            if (distanceSq < nearestSq) {
+                nearestSq = distanceSq;
+            }
+        }
+        if (Double.isInfinite(nearestSq)) {
+            return Double.POSITIVE_INFINITY;
+        }
+        return Math.sqrt(nearestSq);
     }
 
     private Attribute loadScaleAttribute() {
@@ -373,6 +431,8 @@ public class NameTagManager implements UntNametagManagerPaper {
         persistentGlowOverrides.remove(uuid);
         sessionDisplayAnimations.remove(uuid);
         persistentDisplayAnimations.remove(uuid);
+        lastDistanceRefreshTicks.remove(uuid);
+        distanceRefreshCullingBypassed.remove(uuid);
         shiftSystemBlocked.remove(uuid);
     }
 
@@ -2196,6 +2256,31 @@ public class NameTagManager implements UntNametagManagerPaper {
     @Override
     public boolean isShiftSystemBlocked(@NotNull UUID playerId) {
         return shiftSystemBlocked.getOrDefault(playerId, false);
+    }
+
+    @Override
+    public boolean isDistanceRefreshCullingEnabled() {
+        return distanceRefreshCullingEnabled;
+    }
+
+    @Override
+    public void setDistanceRefreshCullingEnabled(boolean enabled) {
+        distanceRefreshCullingEnabled = enabled;
+    }
+
+    @Override
+    public boolean isDistanceRefreshCullingBypassed(@NotNull UUID playerId) {
+        return distanceRefreshCullingBypassed.contains(playerId);
+    }
+
+    @Override
+    public void setDistanceRefreshCullingBypassed(@NotNull UUID playerId, boolean bypassed) {
+        if (bypassed) {
+            distanceRefreshCullingBypassed.add(playerId);
+        } else {
+            distanceRefreshCullingBypassed.remove(playerId);
+        }
+        lastDistanceRefreshTicks.remove(playerId);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add configurable distance-aware refresh culling for periodic nametag placeholder updates
- keep nearby nametags on the base task interval while progressively slowing far-away/no-viewer owners
- add settings.yml migration v6 -> v7 and unit coverage for the interval formula

## Formula
```text
n = clamp((distance - nearDistance) / (maxDistance - nearDistance), 0, 1)
interval = baseInterval + (maxInterval - baseInterval) * n^curve
```

Default behavior keeps nametags within 24 blocks at the base interval, ramps until 96 blocks, then caps at 100 ticks. Far players are still refreshed, just less often.

## Verification
```bash
JAVA_HOME=/home/hermes/.jdks/jdk-21 PATH=/home/hermes/.jdks/jdk-21/bin:$PATH bash ./gradlew :common:cleanTest :common:test --tests org.alexdev.unlimitednametags.config.DistanceRefreshCullingTest :paper:compileJava --rerun-tasks
```

Result: BUILD SUCCESSFUL