### PR TITLE
Fix passenger packet scheduling race

### DIFF
--- a/common/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/packet/PacketNameTag.java
@@ -767,13 +767,7 @@ public abstract class PacketNameTag implements AnimationPoseTarget, NametagPasse
             tn.refreshViewerIfCached(viewerId);
         }
 
-        runtime.runTaskLaterAsync(() -> {
-            final User user = platform.resolveUser(viewerId);
-            if (user == null) {
-                return;
-            }
-            sendPassengersPacket(user);
-        }, 1);
+        runtime.schedulePassengersPacket(viewerId, ownerId);
     }
 
     private boolean isEligibleToShow(@NotNull UUID viewerId) {
@@ -812,13 +806,7 @@ public abstract class PacketNameTag implements AnimationPoseTarget, NametagPasse
             e.spawn(location);
         });
 
-        runtime.runTaskLaterAsync(() -> {
-            final User ownerUser = platform.resolveUser(ownerId);
-            if (ownerUser == null) {
-                return;
-            }
-            sendPassengersPacket(ownerUser);
-        }, 1);
+        runtime.schedulePassengersPacket(ownerId, ownerId);
     }
 
     public void sendPassengersPacket(@NotNull User viewerUser) {
@@ -833,12 +821,7 @@ public abstract class PacketNameTag implements AnimationPoseTarget, NametagPasse
             return;
         }
 
-        getViewers().forEach(viewerId -> {
-            final User user = platform.resolveUser(viewerId);
-            if (user != null) {
-                sendPassengersPacket(user);
-            }
-        });
+        getViewers().forEach(viewerId -> runtime.schedulePassengersPacket(viewerId, ownerId));
     }
 
     private void setPosition() {

--- a/common/src/main/java/org/alexdev/unlimitednametags/platform/NametagRuntime.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/platform/NametagRuntime.java
@@ -44,6 +44,8 @@ public interface NametagRuntime {
 
     void runTaskLaterAsync(@NotNull Runnable task, long delayTicks);
 
+    void schedulePassengersPacket(@NotNull java.util.UUID viewerId, @NotNull java.util.UUID ownerId);
+
     float scaledDisplayScale(@NotNull java.util.UUID ownerId, float displayGroupScale);
 
     void removePassenger(@NotNull java.util.UUID viewerId, int displayEntityId);

--- a/paper/src/main/java/org/alexdev/unlimitednametags/platform/BukkitNametagRuntime.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/platform/BukkitNametagRuntime.java
@@ -1,5 +1,6 @@
 package org.alexdev.unlimitednametags.platform;
 
+import com.github.Anon8281.universalScheduler.scheduling.tasks.MyScheduledTask;
 import com.github.retrooper.packetevents.protocol.player.User;
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
 import org.alexdev.unlimitednametags.config.GlowOverride;
@@ -9,20 +10,29 @@ import org.alexdev.unlimitednametags.api.NametagCustomGlowHandler;
 import org.alexdev.unlimitednametags.packet.CustomDisplayAnimationHandler;
 import org.alexdev.unlimitednametags.packet.CustomGlowHandler;
 import org.alexdev.unlimitednametags.packet.GlowApplyContext;
+import org.alexdev.unlimitednametags.packet.PaperNametagRow;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 public final class BukkitNametagRuntime implements NametagRuntime {
 
+    private static final long PASSENGER_PACKET_DELAY_TICKS = 3L;
+
     private final UnlimitedNameTags plugin;
+    private final Map<PassengerPacketKey, MyScheduledTask> pendingPassengerPackets = new ConcurrentHashMap<>();
 
     public BukkitNametagRuntime(@NotNull UnlimitedNameTags plugin) {
         this.plugin = plugin;
+    }
+
+    private record PassengerPacketKey(@NotNull UUID viewerId, @NotNull UUID ownerId) {
     }
 
     @Override
@@ -106,6 +116,71 @@ public final class BukkitNametagRuntime implements NametagRuntime {
     @Override
     public void runTaskLaterAsync(@NotNull Runnable task, long delayTicks) {
         plugin.getTaskScheduler().runTaskLaterAsynchronously(task, delayTicks);
+    }
+
+    @Override
+    public void schedulePassengersPacket(@NotNull UUID viewerId, @NotNull UUID ownerId) {
+        final PassengerPacketKey key = new PassengerPacketKey(viewerId, ownerId);
+        final MyScheduledTask task = plugin.getTaskScheduler().runTaskLaterAsynchronously(() -> {
+            pendingPassengerPackets.remove(key);
+            if (!canSendPassengersPacket(viewerId, ownerId)) {
+                return;
+            }
+            final User viewerUser = packetUser(viewerId);
+            if (viewerUser == null) {
+                return;
+            }
+            sendPassengersPacket(viewerUser, ownerId);
+        }, PASSENGER_PACKET_DELAY_TICKS);
+
+        final MyScheduledTask previous = pendingPassengerPackets.put(key, task);
+        if (previous != null) {
+            previous.cancel();
+        }
+    }
+
+    private boolean canSendPassengersPacket(@NotNull UUID viewerId, @NotNull UUID ownerId) {
+        final Player viewer = plugin.getPlayerListener().getPlayer(viewerId);
+        final Player owner = plugin.getPlayerListener().getPlayer(ownerId);
+        if (viewer == null || owner == null || !viewer.isOnline() || !owner.isOnline()) {
+            return false;
+        }
+        if (viewer.getWorld() != owner.getWorld()) {
+            return false;
+        }
+        if (!viewer.canSee(owner)) {
+            return false;
+        }
+        if (viewerId.equals(ownerId)) {
+            return plugin.getNametagManager().isEffectiveShowOwnNametag(owner) && hasVisibleNametagRow(owner, viewer);
+        }
+        if (!owner.getTrackedBy().contains(viewer)) {
+            return false;
+        }
+        if (!plugin.getTrackerManager().getTrackedPlayers(viewerId).contains(ownerId)) {
+            return false;
+        }
+        return hasVisibleNametagRow(owner, viewer);
+    }
+
+    private boolean hasVisibleNametagRow(@NotNull Player owner, @NotNull Player viewer) {
+        for (PaperNametagRow tag : plugin.getNametagManager().getPacketDisplays(owner)) {
+            if (tag.canPlayerSee(viewer)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private @Nullable User packetUser(@NotNull UUID playerId) {
+        final Player player = plugin.getPlayerListener().getPlayer(playerId);
+        if (player == null) {
+            return null;
+        }
+        if (com.github.retrooper.packetevents.PacketEvents.getAPI().getPlayerManager().getChannel(player) == null) {
+            return null;
+        }
+        return com.github.retrooper.packetevents.PacketEvents.getAPI().getPlayerManager().getUser(player);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- debounce passenger packet sends per viewer/owner pair instead of sending once per nametag row
- guard scheduled SET_PASSENGERS packets until both players are online, same-world, visible, and still tracked
- validate a viewer still has at least one visible nametag row before sending passengers

## Verification
- JAVA_HOME=/home/hermes/.jdks/jdk-21.0.11+10 ./gradlew build