### PR TITLE
fix: refresh after task clock reset

### DIFF
--- a/common/src/main/java/org/alexdev/unlimitednametags/config/DistanceRefreshCulling.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/config/DistanceRefreshCulling.java
@@ -45,7 +45,7 @@ public final class DistanceRefreshCulling {
     }
 
     public static boolean shouldRefresh(final long elapsedTicks, final int effectiveInterval) {
-        return elapsedTicks >= Math.max(1, effectiveInterval);
+        return elapsedTicks < 0 || elapsedTicks >= Math.max(1, effectiveInterval);
     }
 
     private static double clamp01(final double value) {

--- a/common/src/test/java/org/alexdev/unlimitednametags/config/DistanceRefreshCullingTest.java
+++ b/common/src/test/java/org/alexdev/unlimitednametags/config/DistanceRefreshCullingTest.java
@@ -39,4 +39,9 @@ class DistanceRefreshCullingTest {
         assertTrue(DistanceRefreshCulling.shouldRefresh(40, 40));
         assertTrue(DistanceRefreshCulling.shouldRefresh(80, 40));
     }
+
+    @Test
+    void refreshesWhenElapsedIsNegativeAfterClockReset() {
+        assertTrue(DistanceRefreshCulling.shouldRefresh(-80, 40));
+    }
 }


### PR DESCRIPTION
## Summary

- treat a negative distance-refresh elapsed time as immediately due
- rebase the surviving per-player refresh timestamp on the first sweep after the task clock restarts
- add a regression test for the clock-reset case

## Root cause

`NameTagManager.startTask()` creates a new local `refreshSweepTick` starting at zero, while `lastDistanceRefreshTicks` survives `/unt reload`. Existing online players therefore get a negative elapsed value and their periodic placeholder refreshes are skipped until the new clock catches the old uptime.

The caller already stores the current tick whenever `shouldRefresh(...)` returns `true`, so allowing one refresh for a negative elapsed value safely rebases later comparisons.

## Reproduction

1. Keep a player online long enough for `lastDistanceRefreshTicks` to be populated.
2. Change a dynamic PlaceholderAPI value and confirm the nametag updates.
3. Run `/unt reload`.
4. Change the placeholder again: the nametag stays stale, while `/unt refresh <player>`, relogging, or restarting restores it.

## Verification

- regression test failed before the production change and passed after it
- `JAVA_HOME=/home/hermes/.jdks/jdk-21 ./gradlew clean build --no-daemon`
