### PR TITLE
feat: nametags for non-player entities

### DIFF
--- a/common/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/config/Settings.java
@@ -25,7 +25,7 @@ public class Settings {
             "1 = flat NameTag, 2 = displayGroups with string lines, 3 = displayGroups with structured lines,",
             "4 = unified Background (no type: discriminator) + sectioned settings,",
             "5 = throughWallMode, 6 = glowAnimations + per-row glow,",
-            "7 = distance refresh culling (current)."
+            "7 = distance refresh culling, 8 = entityNametags (current)."
     })
     private int configVersion = SettingsConfigVersion.CURRENT;
 
@@ -45,6 +45,9 @@ public class Settings {
 
     @Comment("Performance and caching settings.")
     private Performance performance = new Performance();
+
+    @Comment("Nametags for non-player entities (named animals, tamed pets).")
+    private EntityNametags entityNametags = new EntityNametags();
 
     @Comment("Match PAPI output strings. Quote reserved YAML 1.1 words: use placeholder: \"Yes\" not Yes (otherwise they become booleans).")
     private Map<String, List<PlaceholderReplacement>> placeholdersReplacements = defaultPlaceholdersReplacements();
@@ -285,6 +288,79 @@ public class Settings {
     }
 
     // ─── Nested types ─────────────────────────────────────────────────────────
+
+    /**
+     * Nametags for non-player entities. Vanilla renders an entity's custom name only when the viewer aims at it from
+     * close range, and a tamed pet inherits its owner's scoreboard team, so a hidden player nametag hides the pet's
+     * name as well. Rendering the name as a text display sidesteps both rules.
+     */
+    @Configuration
+    @Getter
+    @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
+    public static class EntityNametags {
+
+        @Comment("Master switch for entity nametags. Player nametags are unaffected.")
+        private boolean enabled = false;
+
+        @Comment({
+                "Only render entities that carry a custom name (name tag item, /minecraft:data, or a plugin).",
+                "When false, every allowed type gets a nametag built from `format`."
+        })
+        private boolean requireCustomName = true;
+
+        @Comment("Only render entities that are tamed and owned by a player.")
+        private boolean onlyTamed = false;
+
+        @Comment({
+                "Bukkit entity types to render. An empty list means every living non-player entity.",
+                "Applied before `blacklistedEntityTypes`."
+        })
+        private List<String> entityTypes = new ArrayList<>(List.of(
+                "WOLF", "CAT", "PARROT", "HORSE", "DONKEY", "MULE", "LLAMA", "TRADER_LLAMA", "CAMEL", "AXOLOTL", "FOX"));
+
+        @Comment("Entity types never rendered, applied after `entityTypes`.")
+        private List<String> blacklistedEntityTypes = new ArrayList<>(List.of("ARMOR_STAND", "PLAYER"));
+
+        @Comment({
+                "The nametag line. Placeholders: %entity_name%, %entity_type%, %owner_name%, %health%, %max_health%.",
+                "Formatted with behavior.format. PlaceholderAPI is not applied (there is no player context)."
+        })
+        private String format = "%entity_name%";
+
+        @Comment("Extra line under the name for tamed pets. Empty disables it.")
+        private String tamedFormat = "";
+
+        @Comment({
+                "Strip the vanilla custom name from packets for rendered entities so the two do not overlap.",
+                "Disable only if another plugin depends on clients receiving the name."
+        })
+        private boolean hideVanillaName = true;
+
+        @Comment("Ticks between name/health refreshes for rendered entities.")
+        private int refreshInterval = 40;
+
+        @Comment("Vertical offset (blocks) above the entity's height.")
+        private float yOffset = 0.25f;
+
+        private float scale = 1f;
+
+        @Comment("Divided by 160 and sent as the display view_range, matching behavior.viewDistance.")
+        private float viewDistance = 40;
+
+        @Setter
+        @Comment("Billboard constraints for entity nametags (CENTER, HORIZONTAL, VERTICAL, FIXED).")
+        private AbstractDisplayMeta.BillboardConstraints billboard = AbstractDisplayMeta.BillboardConstraints.CENTER;
+
+        private Background background = Background.ofRGB(false, 0, 0, 0, 0, false, false);
+
+        public float getViewDistance() {
+            return viewDistance / 160;
+        }
+
+        public int resolveRefreshInterval() {
+            return Math.max(1, refreshInterval);
+        }
+    }
 
     public record PlaceholderReplacement(String placeholder, String replacement) {
     }

--- a/common/src/main/java/org/alexdev/unlimitednametags/config/SettingsConfigVersion.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/config/SettingsConfigVersion.java
@@ -9,9 +9,9 @@ public final class SettingsConfigVersion {
     }
 
     /**
-     * Latest schema: version 7 introduces distance refresh culling settings.
+     * Latest schema: version 8 introduces the {@code entityNametags} section.
      */
-    public static final int CURRENT = 7;
+    public static final int CURRENT = 8;
 
     /**
      * {@code displayGroups} with {@link Settings.DisplayGroup}, structured {@code lines} as {@code {text, when?}} objects.

--- a/common/src/main/java/org/alexdev/unlimitednametags/config/SettingsYamlMigrator.java
+++ b/common/src/main/java/org/alexdev/unlimitednametags/config/SettingsYamlMigrator.java
@@ -84,6 +84,7 @@ public final class SettingsYamlMigrator {
                 case 4 -> changed |= migrateV4ToV5(root, log);
                 case 5 -> changed |= migrateV5ToV6(root, log);
                 case 6 -> changed |= migrateV6ToV7(root, log);
+                case 7 -> changed |= migrateV7ToV8(root, log);
                 default -> throw new IllegalStateException("Missing settings migrator from v" + v + " to v" + (v + 1));
             }
         }
@@ -760,6 +761,18 @@ public final class SettingsYamlMigrator {
         performance.put("distanceRefreshCulling", culling);
         log.info("Added distance refresh culling settings (v7).");
         return true;
+    }
+
+    /**
+     * {@code entityNametags} is purely additive: ConfigLib writes the section with its defaults and comments when the
+     * bumped {@code configVersion} triggers a save, so there is nothing to rewrite here.
+     */
+    private static boolean migrateV7ToV8(Map<String, Object> root, Logger log) {
+        if (root.containsKey("entityNametags")) {
+            return false;
+        }
+        log.info("Added entity nametag settings (v8).");
+        return false;
     }
 
     private static Map<String, Object> defaultGlowAnimationsYaml() {

--- a/paper/src/main/java/org/alexdev/unlimitednametags/UnlimitedNameTags.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/UnlimitedNameTags.java
@@ -24,6 +24,7 @@ import org.alexdev.unlimitednametags.hook.hat.HatHook;
 import org.alexdev.unlimitednametags.listeners.*;
 import org.alexdev.unlimitednametags.metrics.Metrics;
 import org.alexdev.unlimitednametags.nametags.ConditionalManager;
+import org.alexdev.unlimitednametags.nametags.EntityNameTagManager;
 import org.alexdev.unlimitednametags.nametags.NameTagManager;
 import org.alexdev.unlimitednametags.packet.KyoriManager;
 import org.alexdev.unlimitednametags.packet.PacketManager;
@@ -56,6 +57,7 @@ public final class UnlimitedNameTags extends JavaPlugin implements UnlimitedName
     private boolean isPaper;
     private ConfigManager configManager;
     private NameTagManager nametagManager;
+    private EntityNameTagManager entityNametagManager;
     private PlaceholderManager placeholderManager;
     private VanishManager vanishManager;
     private PacketEventsListener packetEventsListener;
@@ -104,6 +106,13 @@ public final class UnlimitedNameTags extends JavaPlugin implements UnlimitedName
         vanishManager = new VanishManager(this);
         packetManager = new PacketManager(this);
         conditionalManager = new ConditionalManager(this);
+
+        entityNametagManager = new EntityNameTagManager(this);
+        if (isPaper) {
+            Bukkit.getPluginManager().registerEvents(new EntityNametagListener(this), this);
+        } else if (configManager.getSettings().getEntityNametags().isEnabled()) {
+            getLogger().warning("entityNametags requires Paper's entity tracker; the feature stays disabled on Spigot.");
+        }
 
 
         loadCommands();
@@ -441,6 +450,9 @@ public final class UnlimitedNameTags extends JavaPlugin implements UnlimitedName
         }
         if (packetEventsListener != null) {
             packetEventsListener.onDisable();
+        }
+        if (entityNametagManager != null) {
+            entityNametagManager.onDisable();
         }
         if (nametagManager != null) {
             nametagManager.removeAll();

--- a/paper/src/main/java/org/alexdev/unlimitednametags/commands/UntBrigadierCommands.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/commands/UntBrigadierCommands.java
@@ -115,6 +115,7 @@ public final class UntBrigadierCommands {
                 .executes(ctx -> {
                     plugin.getConfigManager().reload();
                     plugin.getNametagManager().reload();
+                    plugin.getEntityNametagManager().reload();
                     plugin.getPlaceholderManager().reload();
                     msg(plugin, ctx.getSource().getSender(), "<green>UnlimitedNameTags has been reloaded!</green>");
                     return Command.SINGLE_SUCCESS;

--- a/paper/src/main/java/org/alexdev/unlimitednametags/listeners/EntityNametagListener.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/listeners/EntityNametagListener.java
@@ -1,0 +1,88 @@
+package org.alexdev.unlimitednametags.listeners;
+
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
+import io.papermc.paper.event.player.PlayerTrackEntityEvent;
+import io.papermc.paper.event.player.PlayerUntrackEntityEvent;
+import lombok.RequiredArgsConstructor;
+import org.alexdev.unlimitednametags.UnlimitedNameTags;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntityTameEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Drives {@link org.alexdev.unlimitednametags.nametags.EntityNameTagManager} from Paper's per-viewer entity tracker.
+ * Only fires for non-player entities; players keep going through {@link PaperTrackerListener}.
+ */
+@RequiredArgsConstructor
+public class EntityNametagListener implements Listener {
+
+    private final UnlimitedNameTags plugin;
+
+    @EventHandler
+    public void onTrack(@NotNull PlayerTrackEntityEvent event) {
+        if (event.getEntity() instanceof Player || !plugin.getEntityNametagManager().isEnabled()) {
+            return;
+        }
+        plugin.getEntityNametagManager().handleTrack(event.getPlayer(), event.getEntity());
+    }
+
+    @EventHandler
+    public void onUntrack(@NotNull PlayerUntrackEntityEvent event) {
+        if (event.getEntity() instanceof Player) {
+            return;
+        }
+        plugin.getEntityNametagManager().handleUntrack(event.getPlayer(), event.getEntity());
+    }
+
+    @EventHandler
+    public void onRemoveFromWorld(@NotNull EntityRemoveFromWorldEvent event) {
+        if (event.getEntity() instanceof Player) {
+            return;
+        }
+        plugin.getEntityNametagManager().handleEntityRemoved(event.getEntity().getUniqueId());
+    }
+
+    @EventHandler
+    public void onDeath(@NotNull EntityDeathEvent event) {
+        plugin.getEntityNametagManager().handleEntityRemoved(event.getEntity().getUniqueId());
+    }
+
+    @EventHandler
+    public void onQuit(@NotNull PlayerQuitEvent event) {
+        plugin.getEntityNametagManager().handleQuit(event.getPlayer());
+    }
+
+    /**
+     * A name tag is applied on the tick after the interaction, so the entity is re-evaluated one tick later.
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onInteract(@NotNull PlayerInteractEntityEvent event) {
+        if (!plugin.getEntityNametagManager().isEnabled()) {
+            return;
+        }
+        scheduleStateChange(event.getRightClicked());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTame(@NotNull EntityTameEvent event) {
+        if (!plugin.getEntityNametagManager().isEnabled()) {
+            return;
+        }
+        scheduleStateChange(event.getEntity());
+    }
+
+    private void scheduleStateChange(@NotNull Entity entity) {
+        plugin.getTaskScheduler().runTaskLater(() -> {
+            if (entity.isValid()) {
+                plugin.getEntityNametagManager().handleStateChanged(entity);
+            }
+        }, 1);
+    }
+}

--- a/paper/src/main/java/org/alexdev/unlimitednametags/listeners/EntityNametagListener.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/listeners/EntityNametagListener.java
@@ -11,6 +11,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntityDismountEvent;
+import org.bukkit.event.entity.EntityMountEvent;
 import org.bukkit.event.entity.EntityTameEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -76,6 +78,30 @@ public class EntityNametagListener implements Listener {
             return;
         }
         scheduleStateChange(event.getEntity());
+    }
+
+    /**
+     * A passenger hides the nametag: the display would have to share the vehicle's passenger slots with the rider,
+     * which shifts it out of place. Removed immediately so it does not linger for a tick on top of the rider.
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onMount(@NotNull EntityMountEvent event) {
+        if (!plugin.getEntityNametagManager().isEnabled()) {
+            return;
+        }
+        plugin.getEntityNametagManager().handleEntityRemoved(event.getMount().getUniqueId());
+    }
+
+    /**
+     * The rider is still attached while this event runs, so the vehicle is re-evaluated a tick later, once its
+     * passenger list is actually empty.
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onDismount(@NotNull EntityDismountEvent event) {
+        if (!plugin.getEntityNametagManager().isEnabled()) {
+            return;
+        }
+        scheduleStateChange(event.getDismounted());
     }
 
     private void scheduleStateChange(@NotNull Entity entity) {

--- a/paper/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
@@ -17,6 +17,7 @@ import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerTe
 import com.google.common.collect.Maps;
 import org.alexdev.unlimitednametags.UnlimitedNameTags;
 import org.alexdev.unlimitednametags.data.TeamData;
+import org.alexdev.unlimitednametags.nametags.EntityNameTagManager;
 import org.alexdev.unlimitednametags.packet.PacketNameTag;
 import org.alexdev.unlimitednametags.packet.PaperNametagRow;
 import org.bukkit.entity.Player;
@@ -25,6 +26,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.*;
 
 public class PacketEventsListener extends PacketListenerAbstract {
+
+    /** {@code Entity.DATA_CUSTOM_NAME}. */
+    private static final int CUSTOM_NAME_INDEX = 2;
+    /** {@code Entity.DATA_CUSTOM_NAME_VISIBLE}. */
+    private static final int CUSTOM_NAME_VISIBLE_INDEX = 3;
 
     private final UnlimitedNameTags plugin;
     private final Map<UUID, Map<String, TeamData>> teams;
@@ -271,6 +277,11 @@ public class PacketEventsListener extends PacketListenerAbstract {
         if (!(event.getPlayer() instanceof Player)) {
             return;
         }
+
+        if (stripManagedEntityName(event)) {
+            return;
+        }
+
         int protocol = event.getUser().getClientVersion().getProtocolVersion();
         //handle metadata for : bedrock players && client with version 1.20.1 or lower
         if (protocol >= 764) {
@@ -292,6 +303,36 @@ public class PacketEventsListener extends PacketListenerAbstract {
                 return;
             }
         }
+    }
+
+    /**
+     * Drops the vanilla custom name from entities the plugin already draws a display for, so the two do not stack.
+     * Index 2 is {@code Entity.DATA_CUSTOM_NAME} and index 3 is {@code Entity.DATA_CUSTOM_NAME_VISIBLE}; both sit on
+     * the base entity class, so the indices hold for every entity type.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private boolean stripManagedEntityName(@NotNull PacketSendEvent event) {
+        final EntityNameTagManager manager = plugin.getEntityNametagManager();
+        if (manager == null || !manager.shouldHideVanillaName()) {
+            return false;
+        }
+
+        final WrapperPlayServerEntityMetadata packet = new WrapperPlayServerEntityMetadata(event);
+        if (!manager.isManaged(packet.getEntityId())) {
+            return false;
+        }
+
+        final List metadata = new ArrayList(packet.getEntityMetadata());
+        final boolean removed = metadata.removeIf(data ->
+                ((EntityData) data).getIndex() == CUSTOM_NAME_INDEX
+                        || ((EntityData) data).getIndex() == CUSTOM_NAME_VISIBLE_INDEX);
+        if (!removed) {
+            return false;
+        }
+
+        packet.setEntityMetadata(metadata);
+        event.markForReEncode(true);
+        return true;
     }
 
     public boolean existsPlayer(@NotNull String name) {

--- a/paper/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/listeners/PacketEventsListener.java
@@ -126,6 +126,7 @@ public class PacketEventsListener extends PacketListenerAbstract {
         final WrapperPlayServerSetPassengers packet = new WrapperPlayServerSetPassengers(event);
         final Optional<? extends Player> player = plugin.getPlayerListener().getPlayerFromEntityId(packet.getEntityId());
         if (player.isEmpty()) {
+            handleEntityPassengers(event, packet);
             return;
         }
 
@@ -153,6 +154,37 @@ public class PacketEventsListener extends PacketListenerAbstract {
         }
 
         plugin.getPacketManager().setPassengers(player.get(), vanillaPassengers);
+    }
+
+    /**
+     * Same re-attach the player path does, for vehicles that are not players. Mounting a renamed horse makes vanilla
+     * send a passenger list holding only the rider, which unmounts the nametag display; it then stays frozen at the
+     * position it last rode to, including after dismounting.
+     */
+    private void handleEntityPassengers(@NotNull PacketSendEvent event, @NotNull WrapperPlayServerSetPassengers packet) {
+        final EntityNameTagManager manager = plugin.getEntityNametagManager();
+        if (manager == null) {
+            return;
+        }
+
+        final List<Integer> displayEntityIds = manager.displayIdsFor(packet.getEntityId());
+        if (displayEntityIds.isEmpty()) {
+            return;
+        }
+
+        final List<Integer> passengers = collectPassengers(packet.getPassengers());
+        final Set<Integer> displayEntityIdSet = new HashSet<>(displayEntityIds);
+        final List<Integer> vanillaPassengers = passengers.stream()
+                .filter(passenger -> !displayEntityIdSet.contains(passenger))
+                .toList();
+        final List<Integer> updatedPassengers = new ArrayList<>(vanillaPassengers.size() + displayEntityIds.size());
+        updatedPassengers.addAll(vanillaPassengers);
+        updatedPassengers.addAll(displayEntityIds);
+
+        if (!updatedPassengers.equals(passengers)) {
+            packet.setPassengers(updatedPassengers.stream().mapToInt(Integer::intValue).toArray());
+            event.markForReEncode(true);
+        }
     }
 
     @NotNull

--- a/paper/src/main/java/org/alexdev/unlimitednametags/nametags/EntityNameTagManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/nametags/EntityNameTagManager.java
@@ -143,6 +143,9 @@ public class EntityNameTagManager {
         if (config.isOnlyTamed() && !isTamed(entity)) {
             return false;
         }
+        if (!entity.getPassengers().isEmpty()) {
+            return false;
+        }
         return !config.isRequireCustomName() || entity.customName() != null;
     }
 
@@ -160,8 +163,8 @@ public class EntityNameTagManager {
             return;
         }
         final TrackedEntity entry = tracked.computeIfAbsent(entity.getUniqueId(), id -> create(entity));
-        entry.display.showToViewer(viewer.getUniqueId());
-        entry.display.applyTextTo(viewer.getUniqueId());
+        entry.display().showToViewer(viewer.getUniqueId());
+        entry.display().applyTextTo(viewer.getUniqueId());
     }
 
     public void handleUntrack(@NotNull final Player viewer, @NotNull final Entity entity) {
@@ -169,15 +172,15 @@ public class EntityNameTagManager {
         if (entry == null) {
             return;
         }
-        entry.display.hideFromViewer(viewer.getUniqueId());
-        if (entry.display.getViewers().isEmpty()) {
+        entry.display().hideFromViewer(viewer.getUniqueId());
+        if (entry.display().getViewers().isEmpty()) {
             remove(entity.getUniqueId());
         }
     }
 
     public void handleQuit(@NotNull final Player viewer) {
         for (final TrackedEntity entry : tracked.values()) {
-            entry.display.handleQuit(viewer.getUniqueId());
+            entry.display().handleQuit(viewer.getUniqueId());
         }
     }
 
@@ -199,7 +202,7 @@ public class EntityNameTagManager {
             return;
         }
         if (entry != null) {
-            entry.display.updateText(buildText(entity));
+            entry.display().updateText(buildText(entity));
             return;
         }
         for (final Player viewer : entity.getTrackedBy()) {
@@ -224,8 +227,7 @@ public class EntityNameTagManager {
         display.setVisible(true);
 
         final TrackedEntity entry = new TrackedEntity(entity, display);
-        entry.display.updateText(buildText(entity));
-        entry.refreshPassengers();
+        entry.display().updateText(buildText(entity));
         byEntityId.put(entity.getEntityId(), entityId);
         return entry;
     }
@@ -233,7 +235,7 @@ public class EntityNameTagManager {
     @Nullable
     private Entity resolveEntity(@NotNull final UUID entityId) {
         final TrackedEntity entry = tracked.get(entityId);
-        return entry != null ? entry.entity : null;
+        return entry != null ? entry.entity() : null;
     }
 
     private void remove(@NotNull final UUID entityId) {
@@ -241,8 +243,8 @@ public class EntityNameTagManager {
         if (entry == null) {
             return;
         }
-        byEntityId.remove(entry.entity.getEntityId());
-        entry.display.remove();
+        byEntityId.remove(entry.entity().getEntityId());
+        entry.display().remove();
     }
 
     public void removeAll() {
@@ -258,12 +260,11 @@ public class EntityNameTagManager {
     private void tick() {
         for (final Map.Entry<UUID, TrackedEntity> mapping : new HashSet<>(tracked.entrySet())) {
             final TrackedEntity entry = mapping.getValue();
-            if (!shouldRender(entry.entity)) {
+            if (!shouldRender(entry.entity())) {
                 remove(mapping.getKey());
                 continue;
             }
-            entry.refreshPassengers();
-            entry.display.updateText(buildText(entry.entity));
+            entry.display().updateText(buildText(entry.entity()));
         }
     }
 
@@ -281,14 +282,31 @@ public class EntityNameTagManager {
 
     // ─── Passengers ───────────────────────────────────────────────────────────
 
+    /**
+     * Display ids riding the given entity. Vanilla rewrites the whole passenger list whenever someone mounts or
+     * dismounts, so the outgoing packet has to have these appended back or the display is silently unmounted and
+     * freezes at its last absolute position.
+     */
+    @NotNull
+    public List<Integer> displayIdsFor(final int bukkitEntityId) {
+        final UUID entityId = byEntityId.get(bukkitEntityId);
+        if (entityId == null) {
+            return List.of();
+        }
+        final TrackedEntity entry = tracked.get(entityId);
+        return entry == null ? List.of() : List.of(entry.display().displayEntityId());
+    }
+
+    /**
+     * A rendered entity never has passengers of its own, so the display is the whole list.
+     */
     public void sendPassengersPacket(@NotNull final User viewer, @NotNull final UUID ownerId) {
         final TrackedEntity entry = tracked.get(ownerId);
         if (entry == null) {
             return;
         }
-        final List<Integer> passengers = new ArrayList<>(entry.realPassengers);
-        passengers.add(entry.display.displayEntityId());
-        plugin.getPacketManager().sendEntityPassengersPacket(viewer, entry.entity.getEntityId(), passengers);
+        plugin.getPacketManager().sendEntityPassengersPacket(viewer, entry.entity().getEntityId(),
+                List.of(entry.display().displayEntityId()));
     }
 
     // ─── Text ─────────────────────────────────────────────────────────────────
@@ -385,31 +403,8 @@ public class EntityNameTagManager {
     }
 
     /**
-     * One rendered entity: the Bukkit handle, its display, and the passenger ids read on the main thread for the
-     * async mount packet.
+     * One rendered entity: the Bukkit handle and its display.
      */
-    private static final class TrackedEntity {
-
-        private final Entity entity;
-        private final EntityTextPacketNameTag display;
-        private volatile List<Integer> realPassengers = List.of();
-
-        private TrackedEntity(@NotNull final Entity entity, @NotNull final EntityTextPacketNameTag display) {
-            this.entity = entity;
-            this.display = display;
-        }
-
-        private void refreshPassengers() {
-            final List<Entity> passengers = entity.getPassengers();
-            if (passengers.isEmpty()) {
-                realPassengers = List.of();
-                return;
-            }
-            final List<Integer> ids = new ArrayList<>(passengers.size());
-            for (final Entity passenger : passengers) {
-                ids.add(passenger.getEntityId());
-            }
-            realPassengers = List.copyOf(ids);
-        }
+    private record TrackedEntity(@NotNull Entity entity, @NotNull EntityTextPacketNameTag display) {
     }
 }

--- a/paper/src/main/java/org/alexdev/unlimitednametags/nametags/EntityNameTagManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/nametags/EntityNameTagManager.java
@@ -1,0 +1,415 @@
+package org.alexdev.unlimitednametags.nametags;
+
+import com.github.Anon8281.universalScheduler.scheduling.tasks.MyScheduledTask;
+import com.github.retrooper.packetevents.protocol.player.User;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.alexdev.unlimitednametags.UnlimitedNameTags;
+import org.alexdev.unlimitednametags.config.Formatter;
+import org.alexdev.unlimitednametags.config.Settings;
+import org.alexdev.unlimitednametags.config.TextFormatter;
+import org.alexdev.unlimitednametags.packet.EntityTextPacketNameTag;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.AnimalTamer;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Tameable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Renders a text display above non-player entities.
+ * <p>
+ * Vanilla only draws an entity's custom name when the viewer aims at it from a few blocks away, and
+ * {@code TamableAnimal.getTeam()} returns the <i>owner's</i> team, so hiding a player's vanilla nametag (which this
+ * plugin does by forcing {@code nameTagVisibility = NEVER}) hides their pets' names as well. Drawing the name as a
+ * display entity is not subject to either rule.
+ */
+public class EntityNameTagManager {
+
+    private final UnlimitedNameTags plugin;
+    private final Map<UUID, TrackedEntity> tracked = new ConcurrentHashMap<>();
+    private final Map<Integer, UUID> byEntityId = new ConcurrentHashMap<>();
+    private Set<EntityType> allowedTypes = EnumSet.noneOf(EntityType.class);
+    private Set<EntityType> blockedTypes = EnumSet.noneOf(EntityType.class);
+    private MyScheduledTask refreshTask;
+
+    public EntityNameTagManager(@NotNull final UnlimitedNameTags plugin) {
+        this.plugin = plugin;
+        reload();
+    }
+
+    @NotNull
+    private Settings.EntityNametags settings() {
+        return plugin.getConfigManager().getSettings().getEntityNametags();
+    }
+
+    public boolean isEnabled() {
+        return settings().isEnabled();
+    }
+
+    /**
+     * Re-resolves the configured type filters and restarts the refresh task. Existing displays are dropped so the
+     * next track event rebuilds them from the new settings.
+     */
+    public void reload() {
+        final Settings.EntityNametags config = settings();
+        this.allowedTypes = parseTypes(config.getEntityTypes());
+        this.blockedTypes = parseTypes(config.getBlacklistedEntityTypes());
+        removeAll();
+        stopTask();
+        if (config.isEnabled() && plugin.isPaper()) {
+            startTask(config.resolveRefreshInterval());
+            adoptAlreadyTrackedEntities();
+        }
+    }
+
+    /**
+     * Track events already fired for entities near online players before this manager existed (server start with
+     * players connected, or {@code /unt reload}), so those are picked up explicitly.
+     */
+    private void adoptAlreadyTrackedEntities() {
+        for (final World world : Bukkit.getWorlds()) {
+            for (final Entity entity : world.getEntities()) {
+                if (shouldRender(entity)) {
+                    handleStateChanged(entity);
+                }
+            }
+        }
+    }
+
+    @NotNull
+    private Set<EntityType> parseTypes(@NotNull final List<String> names) {
+        final Set<EntityType> types = EnumSet.noneOf(EntityType.class);
+        for (final String name : names) {
+            if (name == null || name.isBlank()) {
+                continue;
+            }
+            try {
+                types.add(EntityType.valueOf(name.trim().toUpperCase(Locale.ROOT)));
+            } catch (IllegalArgumentException e) {
+                plugin.getLogger().warning("Unknown entity type in entityNametags: " + name);
+            }
+        }
+        return types;
+    }
+
+    /**
+     * Runs synchronously: the tick reads live entity state (custom name, health, passengers).
+     */
+    private void startTask(final int interval) {
+        refreshTask = plugin.getTaskScheduler().runTaskTimer(this::tick, interval, interval);
+    }
+
+    private void stopTask() {
+        if (refreshTask != null) {
+            refreshTask.cancel();
+            refreshTask = null;
+        }
+    }
+
+    // ─── Eligibility ──────────────────────────────────────────────────────────
+
+    public boolean shouldRender(@NotNull final Entity entity) {
+        final Settings.EntityNametags config = settings();
+        if (!config.isEnabled() || entity instanceof Player || !entity.isValid()) {
+            return false;
+        }
+        if (blockedTypes.contains(entity.getType())) {
+            return false;
+        }
+        if (!allowedTypes.isEmpty() && !allowedTypes.contains(entity.getType())) {
+            return false;
+        }
+        if (allowedTypes.isEmpty() && !(entity instanceof LivingEntity)) {
+            return false;
+        }
+        if (config.isOnlyTamed() && !isTamed(entity)) {
+            return false;
+        }
+        return !config.isRequireCustomName() || entity.customName() != null;
+    }
+
+    private boolean isTamed(@NotNull final Entity entity) {
+        return entity instanceof Tameable tameable && tameable.isTamed();
+    }
+
+    // ─── Tracking ─────────────────────────────────────────────────────────────
+
+    /**
+     * Called when a viewer starts tracking an entity. Creates the display on first use.
+     */
+    public void handleTrack(@NotNull final Player viewer, @NotNull final Entity entity) {
+        if (!shouldRender(entity)) {
+            return;
+        }
+        final TrackedEntity entry = tracked.computeIfAbsent(entity.getUniqueId(), id -> create(entity));
+        entry.display.showToViewer(viewer.getUniqueId());
+        entry.display.applyTextTo(viewer.getUniqueId());
+    }
+
+    public void handleUntrack(@NotNull final Player viewer, @NotNull final Entity entity) {
+        final TrackedEntity entry = tracked.get(entity.getUniqueId());
+        if (entry == null) {
+            return;
+        }
+        entry.display.hideFromViewer(viewer.getUniqueId());
+        if (entry.display.getViewers().isEmpty()) {
+            remove(entity.getUniqueId());
+        }
+    }
+
+    public void handleQuit(@NotNull final Player viewer) {
+        for (final TrackedEntity entry : tracked.values()) {
+            entry.display.handleQuit(viewer.getUniqueId());
+        }
+    }
+
+    public void handleEntityRemoved(@NotNull final UUID entityId) {
+        remove(entityId);
+    }
+
+    /**
+     * Re-evaluates an entity whose state just changed (renamed, tamed). Viewers already tracking it would otherwise
+     * wait for their next track event, which only fires after they walk out of range and back.
+     */
+    public void handleStateChanged(@NotNull final Entity entity) {
+        final boolean eligible = shouldRender(entity);
+        final TrackedEntity entry = tracked.get(entity.getUniqueId());
+        if (!eligible) {
+            if (entry != null) {
+                remove(entity.getUniqueId());
+            }
+            return;
+        }
+        if (entry != null) {
+            entry.display.updateText(buildText(entity));
+            return;
+        }
+        for (final Player viewer : entity.getTrackedBy()) {
+            handleTrack(viewer, entity);
+        }
+    }
+
+    @NotNull
+    private TrackedEntity create(@NotNull final Entity entity) {
+        final Settings.EntityNametags config = settings();
+        final Settings.DisplayGroup group = Settings.DisplayGroup.builder()
+                .line(config.getFormat())
+                .background(config.getBackground())
+                .scale(config.getScale())
+                .yOffset(config.getYOffset())
+                .billboard(config.getBillboard())
+                .build();
+
+        final UUID entityId = entity.getUniqueId();
+        final EntityTextPacketNameTag display = new EntityTextPacketNameTag(
+                plugin, entityId, () -> resolveEntity(entityId), group, config);
+        display.setVisible(true);
+
+        final TrackedEntity entry = new TrackedEntity(entity, display);
+        entry.display.updateText(buildText(entity));
+        entry.refreshPassengers();
+        byEntityId.put(entity.getEntityId(), entityId);
+        return entry;
+    }
+
+    @Nullable
+    private Entity resolveEntity(@NotNull final UUID entityId) {
+        final TrackedEntity entry = tracked.get(entityId);
+        return entry != null ? entry.entity : null;
+    }
+
+    private void remove(@NotNull final UUID entityId) {
+        final TrackedEntity entry = tracked.remove(entityId);
+        if (entry == null) {
+            return;
+        }
+        byEntityId.remove(entry.entity.getEntityId());
+        entry.display.remove();
+    }
+
+    public void removeAll() {
+        for (final UUID entityId : new HashSet<>(tracked.keySet())) {
+            remove(entityId);
+        }
+        tracked.clear();
+        byEntityId.clear();
+    }
+
+    // ─── Refresh ──────────────────────────────────────────────────────────────
+
+    private void tick() {
+        for (final Map.Entry<UUID, TrackedEntity> mapping : new HashSet<>(tracked.entrySet())) {
+            final TrackedEntity entry = mapping.getValue();
+            if (!shouldRender(entry.entity)) {
+                remove(mapping.getKey());
+                continue;
+            }
+            entry.refreshPassengers();
+            entry.display.updateText(buildText(entry.entity));
+        }
+    }
+
+    /**
+     * True when the plugin draws this entity's name, so the vanilla custom name can be stripped from packets.
+     */
+    public boolean isManaged(final int bukkitEntityId) {
+        return byEntityId.containsKey(bukkitEntityId);
+    }
+
+    public boolean shouldHideVanillaName() {
+        final Settings.EntityNametags config = settings();
+        return config.isEnabled() && config.isHideVanillaName();
+    }
+
+    // ─── Passengers ───────────────────────────────────────────────────────────
+
+    public void sendPassengersPacket(@NotNull final User viewer, @NotNull final UUID ownerId) {
+        final TrackedEntity entry = tracked.get(ownerId);
+        if (entry == null) {
+            return;
+        }
+        final List<Integer> passengers = new ArrayList<>(entry.realPassengers);
+        passengers.add(entry.display.displayEntityId());
+        plugin.getPacketManager().sendEntityPassengersPacket(viewer, entry.entity.getEntityId(), passengers);
+    }
+
+    // ─── Text ─────────────────────────────────────────────────────────────────
+
+    @NotNull
+    private Component buildText(@NotNull final Entity entity) {
+        final Settings.EntityNametags config = settings();
+        final TextFormatter textFormatter = plugin.getConfigManager().getSettings().getBehavior().getFormat();
+        final Formatter formatter = Formatter.from(textFormatter);
+
+        Component component = formatter.format(plugin, Bukkit.getConsoleSender(),
+                applyPlaceholders(config.getFormat(), entity, textFormatter));
+
+        final String tamedFormat = config.getTamedFormat();
+        if (tamedFormat != null && !tamedFormat.isBlank() && isTamed(entity)) {
+            component = component.append(Component.newline()).append(
+                    formatter.format(plugin, Bukkit.getConsoleSender(),
+                            applyPlaceholders(tamedFormat, entity, textFormatter)));
+        }
+        return component;
+    }
+
+    @NotNull
+    private String applyPlaceholders(@NotNull final String raw, @NotNull final Entity entity,
+            @NotNull final TextFormatter textFormatter) {
+        return raw.replace("%entity_name%", entityName(entity, textFormatter))
+                .replace("%entity_type%", prettyType(entity.getType()))
+                .replace("%owner_name%", ownerName(entity))
+                .replace("%health%", formatHealth(entity))
+                .replace("%max_health%", formatMaxHealth(entity));
+    }
+
+    /**
+     * Serialises the custom name with the same markup the configured formatter parses, so a coloured name tag keeps
+     * its colours instead of being flattened or double-escaped.
+     */
+    @NotNull
+    private String entityName(@NotNull final Entity entity, @NotNull final TextFormatter textFormatter) {
+        final Component custom = entity.customName();
+        if (custom == null) {
+            return prettyType(entity.getType());
+        }
+        return switch (textFormatter) {
+            case MINIMESSAGE -> MiniMessage.miniMessage().serialize(custom);
+            case LEGACY, UNIVERSAL -> LegacyComponentSerializer.legacyAmpersand().serialize(custom);
+        };
+    }
+
+    @NotNull
+    private String prettyType(@NotNull final EntityType type) {
+        final String[] words = type.name().toLowerCase(Locale.ROOT).split("_");
+        final StringBuilder builder = new StringBuilder();
+        for (final String word : words) {
+            if (word.isEmpty()) {
+                continue;
+            }
+            if (!builder.isEmpty()) {
+                builder.append(' ');
+            }
+            builder.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1));
+        }
+        return builder.toString();
+    }
+
+    @NotNull
+    private String ownerName(@NotNull final Entity entity) {
+        if (!(entity instanceof Tameable tameable)) {
+            return "";
+        }
+        final AnimalTamer owner = tameable.getOwner();
+        return owner != null && owner.getName() != null ? owner.getName() : "";
+    }
+
+    @NotNull
+    private String formatHealth(@NotNull final Entity entity) {
+        if (!(entity instanceof LivingEntity living)) {
+            return "";
+        }
+        return String.valueOf(Math.round(living.getHealth()));
+    }
+
+    @NotNull
+    private String formatMaxHealth(@NotNull final Entity entity) {
+        if (!(entity instanceof LivingEntity living)) {
+            return "";
+        }
+        final AttributeInstance attribute = living.getAttribute(Attribute.MAX_HEALTH);
+        return attribute == null ? "" : String.valueOf(Math.round(attribute.getValue()));
+    }
+
+    public void onDisable() {
+        stopTask();
+        removeAll();
+    }
+
+    /**
+     * One rendered entity: the Bukkit handle, its display, and the passenger ids read on the main thread for the
+     * async mount packet.
+     */
+    private static final class TrackedEntity {
+
+        private final Entity entity;
+        private final EntityTextPacketNameTag display;
+        private volatile List<Integer> realPassengers = List.of();
+
+        private TrackedEntity(@NotNull final Entity entity, @NotNull final EntityTextPacketNameTag display) {
+            this.entity = entity;
+            this.display = display;
+        }
+
+        private void refreshPassengers() {
+            final List<Entity> passengers = entity.getPassengers();
+            if (passengers.isEmpty()) {
+                realPassengers = List.of();
+                return;
+            }
+            final List<Integer> ids = new ArrayList<>(passengers.size());
+            for (final Entity passenger : passengers) {
+                ids.add(passenger.getEntityId());
+            }
+            realPassengers = List.copyOf(ids);
+        }
+    }
+}

--- a/paper/src/main/java/org/alexdev/unlimitednametags/packet/EntityTextPacketNameTag.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/packet/EntityTextPacketNameTag.java
@@ -1,0 +1,110 @@
+package org.alexdev.unlimitednametags.packet;
+
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.util.Vector3f;
+import me.tofaa.entitylib.meta.display.TextDisplayMeta;
+import me.tofaa.entitylib.wrapper.WrapperEntity;
+import net.kyori.adventure.text.Component;
+import org.alexdev.unlimitednametags.UnlimitedNameTags;
+import org.alexdev.unlimitednametags.config.Settings;
+import org.alexdev.unlimitednametags.platform.BukkitEntityNametagPlatform;
+import org.alexdev.unlimitednametags.platform.BukkitEntityNametagRuntime;
+import org.alexdev.unlimitednametags.platform.BukkitNametagMaterialBridge;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Text display mounted on a non-player {@link Entity}.
+ * <p>
+ * The player path seeds each new viewer's display by copying metadata from the owner's own display, but an animal is
+ * never a viewer, so there is no such template. Every visual property is therefore baked into the per-viewer entity
+ * as it is built; {@code modifyAbstractAll} would only reach viewers that already exist. The text is shared by all
+ * viewers because an animal has no relational placeholders.
+ */
+public final class EntityTextPacketNameTag extends TextPacketNameTag {
+
+    private final UnlimitedNameTags plugin;
+    private final Settings.EntityNametags config;
+    private volatile Component text;
+
+    public EntityTextPacketNameTag(@NotNull final UnlimitedNameTags plugin, @NotNull final UUID ownerId,
+            @NotNull final Supplier<Entity> ownerSupplier, @NotNull final Settings.DisplayGroup displayGroup,
+            @NotNull final Settings.EntityNametags config) {
+        super(
+                new BukkitEntityNametagRuntime(plugin),
+                new BukkitEntityNametagPlatform(plugin, ownerId, ownerSupplier),
+                new BukkitNametagMaterialBridge(plugin),
+                ownerId,
+                displayGroup);
+        this.plugin = plugin;
+        this.config = config;
+    }
+
+    @NotNull
+    public UnlimitedNameTags getPlugin() {
+        return plugin;
+    }
+
+    /**
+     * Runs when a viewer first sees the display, which is always after the constructor has assigned {@link #config}.
+     */
+    @Override
+    protected @NotNull Function<User, WrapperEntity> buildBaseSupplier() {
+        final Function<User, WrapperEntity> base = super.buildBaseSupplier();
+        return user -> {
+            final WrapperEntity wrapper = base.apply(user);
+            applyVisuals((TextDisplayMeta) wrapper.getEntityMeta());
+            return wrapper;
+        };
+    }
+
+    private void applyVisuals(@NotNull final TextDisplayMeta meta) {
+        final Component current = text;
+        if (current != null) {
+            meta.setText(current);
+        }
+        meta.setBillboardConstraints(config.getBillboard());
+        meta.setViewRange(config.getViewDistance());
+
+        final float resolvedScale = getScale();
+        meta.setScale(new Vector3f(resolvedScale, resolvedScale, resolvedScale));
+        meta.setTranslation(new Vector3f(0, getBaseTranslationY(), 0));
+
+        final Settings.Background background = config.getBackground();
+        meta.setBackgroundColor(background.getArgb());
+        meta.setShadow(background.shadowed());
+        meta.setSeeThrough(background.seeThrough());
+    }
+
+    /**
+     * Sets the shared text and flushes it to every current viewer.
+     */
+    public void updateText(@NotNull final Component component) {
+        if (component.equals(text)) {
+            return;
+        }
+        this.text = component;
+        for (final UUID viewerId : getViewers()) {
+            if (text(viewerId, component)) {
+                refreshForViewer(viewerId, true);
+            }
+        }
+    }
+
+    /**
+     * Pushes the current text to a viewer that has just been shown the display.
+     */
+    public void applyTextTo(@NotNull final UUID viewerId) {
+        final Component current = text;
+        if (current == null) {
+            return;
+        }
+        if (text(viewerId, current)) {
+            refreshForViewer(viewerId, true);
+        }
+    }
+}

--- a/paper/src/main/java/org/alexdev/unlimitednametags/packet/PacketManager.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/packet/PacketManager.java
@@ -85,6 +85,32 @@ public class PacketManager {
         });
     }
 
+    /**
+     * Mounts entity nametag displays on a non-player entity. Unlike the player path, the full passenger list is
+     * supplied by the caller: it must already contain the entity's real passengers (a ridden horse would otherwise
+     * throw its rider off client-side), and reading those is only safe on the main thread.
+     */
+    public void sendEntityPassengersPacket(@NotNull User viewer, int ownerEntityId, @NotNull List<Integer> passengerIds) {
+        if (passengerIds.isEmpty()) {
+            return;
+        }
+        final int[] passengersArray = passengerIds.stream().mapToInt(Integer::intValue).toArray();
+        executorService.submit(() -> {
+            if (viewer.getChannel() == null) {
+                return;
+            }
+            viewer.sendPacketSilently(new WrapperPlayServerSetPassengers(ownerEntityId, passengersArray));
+        });
+    }
+
+    /**
+     * Entity displays are not tracked in the player passenger map; the destroy packet that removes the display also
+     * unmounts it client-side, so there is nothing to forget here.
+     */
+    public void removeEntityPassenger(int displayEntityId) {
+        this.passengers.removeValueFromAll(displayEntityId);
+    }
+
     public void removePassenger(@NotNull Player player, int passenger) {
         this.passengers.remove(player.getUniqueId(), passenger);
     }

--- a/paper/src/main/java/org/alexdev/unlimitednametags/platform/BukkitEntityNametagPlatform.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/platform/BukkitEntityNametagPlatform.java
@@ -1,0 +1,204 @@
+package org.alexdev.unlimitednametags.platform;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.protocol.world.Location;
+import io.github.retrooper.packetevents.util.SpigotConversionUtil;
+import org.alexdev.unlimitednametags.UnlimitedNameTags;
+import org.alexdev.unlimitednametags.hook.ViaVersionHook;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+/**
+ * {@link NametagPlatformBridge} whose owner is an arbitrary {@link Entity} rather than a player. Viewers are still
+ * players, so every viewer-side question is answered exactly as {@link BukkitNametagPlatform} answers it; only the
+ * owner side resolves an entity.
+ */
+public final class BukkitEntityNametagPlatform implements NametagPlatformBridge {
+
+    private final UnlimitedNameTags plugin;
+    private final UUID ownerId;
+    private final Supplier<Entity> ownerSupplier;
+
+    public BukkitEntityNametagPlatform(@NotNull UnlimitedNameTags plugin, @NotNull UUID ownerId,
+            @NotNull Supplier<Entity> ownerSupplier) {
+        this.plugin = plugin;
+        this.ownerId = ownerId;
+        this.ownerSupplier = ownerSupplier;
+    }
+
+    @Override
+    @NotNull
+    public UUID ownerId() {
+        return ownerId;
+    }
+
+    @Nullable
+    private Entity owner() {
+        final Entity entity = ownerSupplier.get();
+        return entity != null && entity.isValid() ? entity : null;
+    }
+
+    @Override
+    public boolean isOwnerOnline() {
+        return owner() != null;
+    }
+
+    @Override
+    public @Nullable Location anchorLocation(@NotNull UUID owner) {
+        final Entity entity = owner();
+        if (entity == null) {
+            return null;
+        }
+        final org.bukkit.Location bukkit = entity.getLocation();
+        bukkit.setPitch(0);
+        bukkit.setYaw(-180);
+        return SpigotConversionUtil.fromBukkitLocation(bukkit);
+    }
+
+    @Override
+    public @Nullable User resolveUser(@NotNull UUID playerId) {
+        final Player player = plugin.getPlayerListener().getPlayer(playerId);
+        if (player == null) {
+            return null;
+        }
+        if (PacketEvents.getAPI().getPlayerManager().getChannel(player) == null) {
+            return null;
+        }
+        return PacketEvents.getAPI().getPlayerManager().getUser(player);
+    }
+
+    /**
+     * Either side may be the owning entity or a viewing player, so each id is resolved as a player first and as the
+     * owning entity second.
+     */
+    @Override
+    public double distanceSquaredSameWorld(@NotNull UUID a, @NotNull UUID b) {
+        final Entity ea = resolveAny(a);
+        final Entity eb = resolveAny(b);
+        if (ea == null || eb == null || ea.getWorld() != eb.getWorld()) {
+            return -1;
+        }
+        return ea.getLocation().distanceSquared(eb.getLocation());
+    }
+
+    @Nullable
+    private Entity resolveAny(@NotNull UUID id) {
+        if (id.equals(ownerId)) {
+            return owner();
+        }
+        return plugin.getPlayerListener().getPlayer(id);
+    }
+
+    @Override
+    public boolean isSneaking(@NotNull UUID owner) {
+        return false;
+    }
+
+    @Override
+    public float resolveDisplayScale(@NotNull UUID owner, float configScale) {
+        return configScale;
+    }
+
+    @Override
+    public boolean viewerSupportsTextDisplay(@NotNull UUID viewerId) {
+        final Player viewer = plugin.getPlayerListener().getPlayer(viewerId);
+        if (viewer == null) {
+            return false;
+        }
+        return plugin.getHook(ViaVersionHook.class).map(h -> !h.hasNotTextDisplays(viewer)).orElse(true);
+    }
+
+    @Override
+    public boolean isEligibleToShow(@NotNull UUID owner, @NotNull UUID viewerId, boolean visible, boolean viewerAlreadySeeing) {
+        return nametagShowBlockReason(owner, viewerId, visible, viewerAlreadySeeing) == null;
+    }
+
+    @Override
+    public @Nullable String nametagShowBlockReason(@NotNull UUID owner, @NotNull UUID viewerId, boolean visible,
+            boolean viewerAlreadySeeing) {
+        final Player viewer = plugin.getPlayerListener().getPlayer(viewerId);
+        final Entity ownerEntity = owner();
+        if (!visible) {
+            return "nametag is not marked visible";
+        }
+        if (viewer == null) {
+            return "viewer is not loaded or online";
+        }
+        if (ownerEntity == null) {
+            return "owner entity is not loaded";
+        }
+        if (!viewerSupportsTextDisplay(viewerId)) {
+            return "viewer client does not support text displays";
+        }
+        if (viewer.getWorld() != ownerEntity.getWorld()) {
+            return "viewer is in world " + viewer.getWorld().getName()
+                    + " but owner is in world " + ownerEntity.getWorld().getName();
+        }
+        if (resolveUser(viewerId) == null) {
+            return "PacketEvents user is not loaded for viewer";
+        }
+        if (!viewer.hasPermission("unt.showentitynametags")) {
+            return "viewer lacks permission unt.showentitynametags";
+        }
+        if (plugin.getNametagManager().isHiddenOtherNametags(viewer)) {
+            return "viewer has hidden other nametags";
+        }
+        if (viewerAlreadySeeing) {
+            return "viewer is already seeing this nametag";
+        }
+        return null;
+    }
+
+    @Override
+    public @Nullable String playerName(@NotNull UUID playerId) {
+        if (playerId.equals(ownerId)) {
+            final Entity entity = owner();
+            return entity != null ? entity.getType().name() + "#" + entity.getEntityId() : null;
+        }
+        final Player player = plugin.getPlayerListener().getPlayer(playerId);
+        return player != null ? player.getName() : null;
+    }
+
+    @Override
+    public boolean isEffectiveShowOwnNametag(@NotNull UUID owner) {
+        return false;
+    }
+
+    /**
+     * The display rides the entity, so this position only seeds the spawn packet; the client keeps it in place from
+     * the passenger mount afterwards.
+     */
+    @Override
+    public @Nullable Location offsetDisplayLocation(float displayScale) {
+        final Entity entity = owner();
+        if (entity == null) {
+            return null;
+        }
+        final org.bukkit.Location bukkit = entity.getLocation();
+        bukkit.setPitch(0);
+        bukkit.setYaw(-180);
+        bukkit.setY(bukkit.getY() + entity.getHeight() * displayScale);
+        return SpigotConversionUtil.fromBukkitLocation(bukkit);
+    }
+
+    @Override
+    public boolean viewerLacksTextDisplaySupport(@NotNull UUID viewerId) {
+        return !viewerSupportsTextDisplay(viewerId);
+    }
+
+    @Override
+    public boolean hasLineOfSight(@NotNull UUID viewerId, @NotNull UUID owner) {
+        final Player viewer = plugin.getPlayerListener().getPlayer(viewerId);
+        final Entity ownerEntity = owner();
+        if (viewer == null || ownerEntity == null) {
+            return false;
+        }
+        return viewer.hasLineOfSight(ownerEntity);
+    }
+}

--- a/paper/src/main/java/org/alexdev/unlimitednametags/platform/BukkitEntityNametagRuntime.java
+++ b/paper/src/main/java/org/alexdev/unlimitednametags/platform/BukkitEntityNametagRuntime.java
@@ -1,0 +1,133 @@
+package org.alexdev.unlimitednametags.platform;
+
+import com.github.retrooper.packetevents.protocol.player.User;
+import org.alexdev.unlimitednametags.UnlimitedNameTags;
+import org.alexdev.unlimitednametags.config.GlowOverride;
+import org.alexdev.unlimitednametags.config.Settings;
+import org.alexdev.unlimitednametags.packet.CustomDisplayAnimationHandler;
+import org.alexdev.unlimitednametags.packet.CustomGlowHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * {@link NametagRuntime} for entity nametags. Everything platform-wide is delegated to the player runtime; the
+ * owner-scoped methods are overridden because an animal has no attributes, no PlaceholderAPI context, and mounts its
+ * display through the entity passenger list instead of the player one.
+ */
+public final class BukkitEntityNametagRuntime implements NametagRuntime {
+
+    private final UnlimitedNameTags plugin;
+    private final NametagRuntime delegate;
+
+    public BukkitEntityNametagRuntime(@NotNull UnlimitedNameTags plugin) {
+        this.plugin = plugin;
+        this.delegate = plugin.getNametagRuntime();
+    }
+
+    @Override
+    public int nextEntityId() {
+        return delegate.nextEntityId();
+    }
+
+    @Override
+    @NotNull
+    public Settings settings() {
+        return delegate.settings();
+    }
+
+    @Override
+    public boolean isNametagDebug() {
+        return delegate.isNametagDebug();
+    }
+
+    @Override
+    public void logInfo(@NotNull String message) {
+        delegate.logInfo(message);
+    }
+
+    @Override
+    public void logWarning(@NotNull String message) {
+        delegate.logWarning(message);
+    }
+
+    @Override
+    public void logWarning(@NotNull String message, @NotNull Throwable error) {
+        delegate.logWarning(message, error);
+    }
+
+    @Override
+    public @Nullable CustomDisplayAnimationHandler resolveCustomAnimationHandler(@NotNull String id) {
+        return delegate.resolveCustomAnimationHandler(id);
+    }
+
+    @Override
+    public @Nullable GlowOverride resolveGlowAnimation(@NotNull String id) {
+        return delegate.resolveGlowAnimation(id);
+    }
+
+    @Override
+    @NotNull
+    public Set<String> registeredGlowAnimationIds() {
+        return delegate.registeredGlowAnimationIds();
+    }
+
+    @Override
+    public @Nullable CustomGlowHandler resolveCustomGlowHandler(@NotNull String id) {
+        return delegate.resolveCustomGlowHandler(id);
+    }
+
+    @Override
+    @NotNull
+    public Set<String> registeredCustomGlowHandlerIds() {
+        return delegate.registeredCustomGlowHandlerIds();
+    }
+
+    @Override
+    public void runTaskLaterAsync(@NotNull Runnable task, long delayTicks) {
+        delegate.runTaskLaterAsync(task, delayTicks);
+    }
+
+    /**
+     * Animals have no scale attribute, so the configured scale is already the final one.
+     */
+    @Override
+    public float scaledDisplayScale(@NotNull UUID ownerId, float displayGroupScale) {
+        return displayGroupScale;
+    }
+
+    @Override
+    public void removePassenger(@NotNull UUID viewerId, int displayEntityId) {
+        plugin.getPacketManager().removeEntityPassenger(displayEntityId);
+    }
+
+    @Override
+    public void removePassengerFromAll(int displayEntityId) {
+        plugin.getPacketManager().removeEntityPassenger(displayEntityId);
+    }
+
+    @Override
+    public void sendPassengersPacket(@NotNull User viewerUser, @NotNull UUID ownerId) {
+        plugin.getEntityNametagManager().sendPassengersPacket(viewerUser, ownerId);
+    }
+
+    /**
+     * Entity nametags use a single configured line with no JEXL conditions.
+     */
+    @Override
+    public boolean isDisplayGroupActive(@NotNull UUID ownerId, @NotNull Settings.DisplayGroup group) {
+        return true;
+    }
+
+    /**
+     * PlaceholderAPI needs a player context that an animal cannot provide; entity placeholders are resolved by
+     * {@code EntityNameTagManager} before the text reaches the display.
+     */
+    @Override
+    @NotNull
+    public String expandPlaceholdersForOwner(@NotNull UUID ownerId, @NotNull String raw) {
+        return raw;
+    }
+}

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -29,6 +29,8 @@ permissions:
     default: true
   unt.showownnametag:
     default: true
+  unt.showentitynametags:
+    default: true
   unt.reload:
     default: op
   unt.debug:


### PR DESCRIPTION
Vanilla only shows an entity's custom name if you're aiming at it from a few blocks away. And since tamed pets inherit their owner's scoreboard team, hiding player nametags through that team hides pet names right along with them. A named wolf shows nothing at all until its owner leaves the world.

This adds an opt-in `entityNametags` section that draws those names as text displays instead, so neither restriction applies.

### Implementation

Displays and viewers are already handled by UUID rather than by player, so the existing text display code is reused as-is behind an entity-backed implementation. The player path is untouched.

Two things needed separate handling. A new viewer normally receives its display settings copied from the owner's own nametag, and an animal doesn't have one, so scale, billboard, background and view range are applied as each viewer's display is created. And because the display rides the entity, it has to survive vanilla rewriting the passenger list on every mount and dismount, which until now was only handled for players.

### Ridden entities

Nametags are hidden while something is riding the entity. A display sharing passenger slots with a rider ends up out of position, so it's removed on mount and restored a tick after dismount, once the passenger list has emptied.

### Config

```yaml
entityNametags:
  enabled: false
  requireCustomName: true
  onlyTamed: false
  entityTypes: [WOLF, CAT, PARROT, HORSE, ...]   # empty = every living non-player entity
  blacklistedEntityTypes: [ARMOR_STAND, PLAYER]
  format: '%entity_name%'                         # %entity_type%, %owner_name%, %health%, %max_health%
  tamedFormat: ''
  hideVanillaName: true
  refreshInterval: 40
  yOffset: 0.25
  scale: 1.0
  viewDistance: 40.0
  billboard: CENTER
  background: { enabled: false, ... }
```

`hideVanillaName` keeps the vanilla name from reaching clients for entities we draw. Without it untamed animals show both at close range.

### Notes

* Off by default.
* Paper only, since it relies on Paper's per-viewer entity tracking. Stays disabled with a warning on Spigot.
* New permission `unt.showentitynametags`, default true.
* Config version bumped to 8. The section is additive, so nothing existing gets rewritten.
* One shared text for every viewer, and no PlaceholderAPI, since there's no player context to resolve against.

### Testing

Tested on Paper 1.21.11 with a config migrated up from a live 1.6.11 install. Named and tamed animals render and follow correctly, mounting hides the nametag, dismounting brings it back.
